### PR TITLE
feat(layouts): añadir CVLayout y soporte noindex en BaseLayout

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,9 +5,10 @@ import { SITE } from "@/config/site";
 interface Props {
   title?: string;
   description?: string;
+  noindex?: boolean;
 }
 
-const { title, description = SITE.description } = Astro.props;
+const { title, description = SITE.description, noindex = false } = Astro.props;
 
 const pageTitle = title ? `${title} — ${SITE.name}` : SITE.name;
 ---
@@ -22,6 +23,8 @@ const pageTitle = title ? `${title} — ${SITE.name}` : SITE.name;
     <title>{pageTitle}</title>
     <meta name="description" content={description} />
     <meta name="author" content={SITE.author} />
+
+    {noindex && <meta name="robots" content="noindex, nofollow" />}
 
     <!-- Open Graph -->
     <meta property="og:title" content={pageTitle} />

--- a/src/layouts/CVLayout.astro
+++ b/src/layouts/CVLayout.astro
@@ -1,0 +1,21 @@
+---
+import BaseLayout from "./BaseLayout.astro";
+import Header from "@/components/common/Header.astro";
+import Footer from "@/components/common/Footer.astro";
+
+interface Props {
+  title?: string;
+  description?: string;
+  noindex?: boolean;
+}
+
+const { title, description, noindex = false } = Astro.props;
+---
+
+<BaseLayout title={title} description={description} noindex={noindex}>
+  <Header />
+  <main class="mx-auto max-w-5xl space-y-8 px-6 py-12">
+    <slot />
+  </main>
+  <Footer />
+</BaseLayout>

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -1,7 +1,7 @@
 ---
 export const prerender = false;
 
-import MainLayout from "@/layouts/MainLayout.astro";
+import CVLayout from "@/layouts/CVLayout.astro";
 import { getCVComplete } from "@/services/api/cv.service";
 import { ApiError } from "@/services/api/base.service";
 import ProfileCard from "@/components/cv/ProfileCard.astro";
@@ -33,21 +33,19 @@ try {
 }
 ---
 
-<MainLayout title="CV">
-  <div class="mx-auto max-w-5xl space-y-8 px-6 py-12">
-    {
-      apiError ? (
-        <div class="rounded-lg border border-red-200 bg-red-50 p-6 text-red-800">
-          <p class="font-medium">No se pudo cargar el CV</p>
-          <p class="mt-1 text-sm">{apiError}</p>
-        </div>
-      ) : (
-        <>
-          <ProfileCard profile={cv!.profile} contactInfo={cv!.contact_info} />
-          {cv!.work_experiences.length > 0 && <ExperienceList experiences={cv!.work_experiences} />}
-          {cv!.skills.length > 0 && <SkillList skills={cv!.skills} />}
-        </>
-      )
-    }
-  </div>
-</MainLayout>
+<CVLayout title="CV">
+  {
+    apiError ? (
+      <div class="rounded-lg border border-red-200 bg-red-50 p-6 text-red-800">
+        <p class="font-medium">No se pudo cargar el CV</p>
+        <p class="mt-1 text-sm">{apiError}</p>
+      </div>
+    ) : (
+      <>
+        <ProfileCard profile={cv!.profile} contactInfo={cv!.contact_info} />
+        {cv!.work_experiences.length > 0 && <ExperienceList experiences={cv!.work_experiences} />}
+        {cv!.skills.length > 0 && <SkillList skills={cv!.skills} />}
+      </>
+    )
+  }
+</CVLayout>


### PR DESCRIPTION
## Resumen

- Creación de `CVLayout.astro` que envuelve `BaseLayout` con `Header`, `Footer` y contenedor `max-w-5xl` preconfigurado
- Añadida prop `noindex` a `BaseLayout` para controlar la indexación por layout
- Migración de `cv.astro` de `MainLayout` a `CVLayout`, eliminando el wrapper div inline

## Cambios

| Archivo | Tipo | Descripción |
|---|---|---|
| `src/layouts/CVLayout.astro` | Nuevo | Layout dedicado para la página del CV |
| `src/layouts/BaseLayout.astro` | Modificado | Prop `noindex?: boolean` con meta tag condicional |
| `src/pages/cv.astro` | Modificado | Usa `CVLayout` en lugar de `MainLayout` |

## Plan de pruebas

- [x] `npm run build` pasa sin errores
- [x] La página `/cv` renderiza correctamente con el nuevo layout
- [x] El contenedor `max-w-5xl` aplica en la página del CV
- [ ] `BaseLayout` con `noindex=true` genera el meta tag `robots`

Closes #10