### PR TITLE
feat(common): componentes comunes — issue #12

### DIFF
--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -1,38 +1,7 @@
 ---
 import { SITE } from "@/config/site";
 import { ROUTES } from "@/config/constants";
-
-const current = Astro.url.pathname;
-
-const links = [
-  {
-    label: "Inicio",
-    href: "/#inicio",
-    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>`,
-  },
-  {
-    label: "Experiencia",
-    href: "/#experiencia",
-    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="14" x="2" y="7" rx="2" ry="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/></svg>`,
-  },
-  {
-    label: "Estudios",
-    href: "/#estudios",
-    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10v6M2 10l10-5 10 5-10 5z"/><path d="M6 12v5c3 3 9 3 12 0v-5"/></svg>`,
-  },
-  {
-    label: "Proyectos",
-    href: "/#proyectos",
-    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>`,
-  },
-  {
-    label: "Contacto",
-    href: "/#contacto",
-    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>`,
-  },
-];
-
-const isHome = current === "/";
+import Navigation from "@/components/common/Navigation.astro";
 ---
 
 <header class="nav-header">
@@ -42,21 +11,7 @@ const isHome = current === "/";
       {SITE.author}
     </a>
 
-    <nav aria-label="Navegación principal">
-      <ul class="nav-links">
-        {
-          links.map(({ label, href, icon }) => (
-            <li>
-              <a
-                href={href}
-                class="nav-link"
-                set:html={`<span class="nav-link-icon">${icon}</span><span>${label}</span>`}
-              />
-            </li>
-          ))
-        }
-      </ul>
-    </nav>
+    <Navigation />
 
     <!-- Badge CV -->
     <a href={ROUTES.cv} target="_blank" class="hero-badge">
@@ -122,7 +77,7 @@ const isHome = current === "/";
     display: inline-block;
   }
 
-  .nav-links {
+  :global(.nav-links) {
     display: flex;
     align-items: center;
     gap: 4px;
@@ -131,7 +86,7 @@ const isHome = current === "/";
     padding: 0;
   }
 
-  .nav-link {
+  :global(.nav-link) {
     display: inline-flex;
     align-items: center;
     gap: 6px;
@@ -146,12 +101,12 @@ const isHome = current === "/";
       color var(--transition);
   }
 
-  .nav-link:hover {
+  :global(.nav-link:hover) {
     background: var(--soft);
     color: var(--blue);
   }
 
-  .nav-link-icon {
+  :global(.nav-link-icon) {
     display: flex;
     align-items: center;
     opacity: 0.7;
@@ -180,17 +135,17 @@ const isHome = current === "/";
   }
 
   @media (max-width: 640px) {
-    .nav-links {
+    :global(.nav-links) {
       gap: 2px;
     }
-    .nav-link {
+    :global(.nav-link) {
       padding: 6px 10px;
       font-size: 13px;
     }
-    .nav-link span:not(.nav-link-icon) {
+    :global(.nav-link span:not(.nav-link-icon)) {
       display: none;
     }
-    .nav-link-icon {
+    :global(.nav-link-icon) {
       opacity: 1;
     }
   }

--- a/src/components/common/Navigation.astro
+++ b/src/components/common/Navigation.astro
@@ -2,28 +2,49 @@
 import { ROUTES } from "@/config/constants";
 
 const links = [
-  { label: "Inicio", href: ROUTES.home },
-  { label: "CV", href: ROUTES.cv },
+  {
+    label: "Inicio",
+    href: "/#inicio",
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>`,
+  },
+  {
+    label: "Experiencia",
+    href: "/#experiencia",
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="14" x="2" y="7" rx="2" ry="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/></svg>`,
+  },
+  {
+    label: "Estudios",
+    href: "/#estudios",
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10v6M2 10l10-5 10 5-10 5z"/><path d="M6 12v5c3 3 9 3 12 0v-5"/></svg>`,
+  },
+  {
+    label: "Proyectos",
+    href: "/#proyectos",
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>`,
+  },
+  {
+    label: "Contacto",
+    href: "/#contacto",
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>`,
+  },
+  {
+    label: "CV",
+    href: ROUTES.cv,
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>`,
+  },
 ];
-
-const current = Astro.url.pathname;
 ---
 
 <nav aria-label="Navegación principal">
-  <ul class="flex gap-6">
+  <ul class="nav-links">
     {
-      links.map(({ label, href }) => (
+      links.map(({ label, href, icon }) => (
         <li>
           <a
             href={href}
-            aria-current={current === href ? "page" : undefined}
-            class:list={[
-              "text-sm font-medium transition-colors hover:text-slate-900",
-              current === href ? "text-slate-900" : "text-slate-500",
-            ]}
-          >
-            {label}
-          </a>
+            class="nav-link"
+            set:html={`<span class="nav-link-icon">${icon}</span><span>${label}</span>`}
+          />
         </li>
       ))
     }

--- a/src/components/common/SEO.astro
+++ b/src/components/common/SEO.astro
@@ -1,0 +1,37 @@
+---
+import { SITE } from "@/config/site";
+import { SEO_DEFAULTS } from "@/config/seo";
+import type { SEOProps } from "@/config/seo";
+
+type Props = SEOProps;
+
+const {
+  title,
+  description = SEO_DEFAULTS.description,
+  canonical = SEO_DEFAULTS.canonical,
+  noindex = false,
+} = Astro.props;
+
+const pageTitle = title ? `${title} — ${SITE.name}` : SITE.name;
+---
+
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="generator" content={Astro.generator} />
+
+<title>{pageTitle}</title>
+<meta name="description" content={description} />
+<meta name="author" content={SITE.author} />
+
+{noindex && <meta name="robots" content="noindex, nofollow" />}
+{canonical && <link rel="canonical" href={canonical} />}
+
+<!-- Open Graph -->
+<meta property="og:title" content={pageTitle} />
+<meta property="og:description" content={description} />
+<meta property="og:type" content="website" />
+<meta property="og:url" content={canonical ?? SITE.url} />
+
+<!-- Favicon -->
+<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+<link rel="icon" href="/favicon.ico" />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,40 +1,18 @@
 ---
 import "@/styles/global.css";
 import { SITE } from "@/config/site";
+import SEO from "@/components/common/SEO.astro";
+import type { SEOProps } from "@/config/seo";
 
-interface Props {
-  title?: string;
-  description?: string;
-  noindex?: boolean;
-}
+type Props = SEOProps;
 
-const { title, description = SITE.description, noindex = false } = Astro.props;
-
-const pageTitle = title ? `${title} — ${SITE.name}` : SITE.name;
+const { title, description, canonical, noindex } = Astro.props;
 ---
 
 <!doctype html>
 <html lang={SITE.locale}>
   <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="generator" content={Astro.generator} />
-
-    <title>{pageTitle}</title>
-    <meta name="description" content={description} />
-    <meta name="author" content={SITE.author} />
-
-    {noindex && <meta name="robots" content="noindex, nofollow" />}
-
-    <!-- Open Graph -->
-    <meta property="og:title" content={pageTitle} />
-    <meta property="og:description" content={description} />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content={SITE.url} />
-
-    <!-- Favicon -->
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="icon" href="/favicon.ico" />
+    <SEO title={title} description={description} canonical={canonical} noindex={noindex} />
   </head>
   <body>
     <slot />

--- a/src/layouts/CVLayout.astro
+++ b/src/layouts/CVLayout.astro
@@ -1,4 +1,7 @@
 ---
+// CVLayout does not use Header or Footer intentionally. It is a specialized
+// layout for CV viewing and download, with its own toolbar (back link, print/
+// download action). The standard site navigation is irrelevant in this context.
 import BaseLayout from "./BaseLayout.astro";
 
 interface Props {


### PR DESCRIPTION
## Resumen

- Creado `SEO.astro`: centraliza todos los meta tags (`title`, `description`, OG, robots, canonical, favicon) con props `SEOProps` y valores por defecto desde `SITE`
- Actualizado `BaseLayout.astro`: usa `<SEO>` en lugar de meta tags inline; gana prop `canonical`
- Reescrito `Navigation.astro`: ahora incluye los 6 enlaces completos con iconos SVG (era un stub de 2 enlaces)
- Refactorizado `Header.astro`: delega la navegación en `<Navigation />` y elimina la variable `isHome` no usada
- Documentado `CVLayout.astro`: comentario que explica por qué no reutiliza `Header`/`Footer` (layout especializado para CV)

## Plan de pruebas

- [x] La home (`/`) carga correctamente con Header y Footer visibles
- [x] La navegación muestra los 6 enlaces con sus iconos
- [x] Los meta tags SEO se renderizan correctamente en el `<head>` (title, description, OG)
- [x] La página `/cv` carga con su toolbar propio sin Header/Footer
- [x] El proyecto compila sin errores (`astro build`)

Closes #12