### PR TITLE
feat: página /projects con grid de tarjetas de proyectos

### DIFF
--- a/src/components/common/Navigation.astro
+++ b/src/components/common/Navigation.astro
@@ -19,7 +19,7 @@ const links = [
   },
   {
     label: "Proyectos",
-    href: "/#proyectos",
+    href: ROUTES.projects,
     icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>`,
   },
   {

--- a/src/components/home/ProjectsSection.astro
+++ b/src/components/home/ProjectsSection.astro
@@ -1,4 +1,6 @@
 ---
+import { ROUTES } from "@/config/constants";
+
 const projects = [
   {
     subtitle: "Portfolio · Personal project",
@@ -122,6 +124,27 @@ const projects = [
           </div>
         ))
       }
+    </div>
+
+    <div class="projects-cta">
+      <a href={ROUTES.projects} class="projects-cta-link">
+        Ver todos los proyectos
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <line x1="5" y1="12" x2="19" y2="12"></line>
+          <polyline points="12 5 19 12 12 19"></polyline>
+        </svg>
+      </a>
     </div>
   </div>
 </section>
@@ -306,6 +329,35 @@ const projects = [
     background: var(--blue-2);
     border-color: var(--blue-2);
     color: #fff;
+  }
+
+  .projects-cta {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 24px;
+  }
+
+  .projects-cta-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13.5px;
+    font-weight: 600;
+    color: var(--blue);
+    text-decoration: none;
+    padding: 7px 16px;
+    border-radius: var(--radius-pill);
+    border: 1px solid var(--line);
+    background: var(--blue-soft);
+    transition:
+      background var(--transition),
+      border-color var(--transition);
+  }
+
+  .projects-cta-link:hover {
+    background: var(--blue);
+    color: #fff;
+    border-color: var(--blue);
   }
 
   @media (max-width: 600px) {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -3,5 +3,6 @@ export const API_URL = import.meta.env.PUBLIC_API_URL as string;
 export const ROUTES = {
   home: "/",
   cv: "/cv",
+  projects: "/projects",
   notFound: "/404",
 } as const;

--- a/src/config/seo.ts
+++ b/src/config/seo.ts
@@ -23,6 +23,10 @@ export const PAGE_SEO: Record<string, SEOProps> = {
     title: "CV",
     description: `Curriculum vitae de ${SITE.author} — trayectoria profesional, habilidades y formación.`,
   },
+  projects: {
+    title: "Proyectos",
+    description: `Proyectos de ${SITE.author} — casos reales con stack técnico, código y demos.`,
+  },
   notFound: {
     title: "Página no encontrada",
     description: "La página que buscas no existe.",

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,0 +1,382 @@
+---
+import MainLayout from "@/layouts/MainLayout.astro";
+import { PAGE_SEO } from "@/config/seo";
+
+interface MockProject {
+  subtitle: string;
+  title: string;
+  description: string;
+  tags: string[];
+  gradient: string;
+  liveUrl: string | null;
+  repoUrl: string | null;
+}
+
+// Datos estáticos — la integración real con la API va en EPIC 4.4
+// La estructura refleja la interfaz Project de cv.types.ts
+// (title, description, technologies/tags, live_url, repo_url)
+const projects: MockProject[] = [
+  {
+    subtitle: "Portfolio · Proyecto personal",
+    title: "azfe.dev — Portfolio profesional",
+    description:
+      "Portfolio y CV online construido con Astro + FastAPI. Backend con Clean Architecture, MongoDB y generacion de PDF. Frontend SSG/SSR desplegado en Vercel.",
+    tags: ["Astro", "FastAPI", "MongoDB", "Python", "Tailwind"],
+    gradient: "linear-gradient(135deg, #0e2a5c 0%, #1e6bf7 100%)",
+    liveUrl: "https://azfe.dev",
+    repoUrl: "https://github.com/azfe/portfolio",
+  },
+  {
+    subtitle: "API · Backend project",
+    title: "REST API con Clean Architecture",
+    description:
+      "API REST modular con FastAPI, arquitectura limpia por capas (Domain, Application, Infrastructure), tests unitarios e integracion con pytest.",
+    tags: ["FastAPI", "Python", "MongoDB", "pytest", "Docker"],
+    gradient: "linear-gradient(135deg, #064e2e 0%, #0f8a4a 100%)",
+    liveUrl: null,
+    repoUrl: "https://github.com/azfe",
+  },
+  {
+    subtitle: "CLI tool · Utility",
+    title: "Dev CLI utilities",
+    description:
+      "Conjunto de utilidades de linea de comandos para automatizar tareas de desarrollo. Gestion de entornos, scaffolding y helpers de proyecto.",
+    tags: ["Python", "Typer", "Rich", "Click"],
+    gradient: "linear-gradient(135deg, #5a0a1e 0%, #c23a52 100%)",
+    liveUrl: null,
+    repoUrl: "https://github.com/azfe",
+  },
+  {
+    subtitle: "Automation · Script",
+    title: "Data pipeline automatizado",
+    description:
+      "Pipeline ETL para procesamiento de datos con Python. Extraccion, transformacion y carga de datos con manejo de errores y logging estructurado.",
+    tags: ["Python", "Pandas", "SQLAlchemy", "Logging"],
+    gradient: "linear-gradient(135deg, #2d1a6e 0%, #6a3acf 100%)",
+    liveUrl: null,
+    repoUrl: "https://github.com/azfe",
+  },
+];
+---
+
+<MainLayout title={PAGE_SEO.projects!.title} description={PAGE_SEO.projects!.description}>
+  <section class="projects-page" id="proyectos">
+    <div class="page-wrap">
+      <!-- Cabecera de página -->
+      <header class="page-header">
+        <p class="page-overline">Portfolio</p>
+        <h1 class="page-title">Proyectos</h1>
+        <p class="page-intro">
+          Casos reales en los que aplico arquitecturas limpias, buenas practicas y tecnologias
+          modernas. Cada proyecto refleja mi forma de resolver problemas de forma estructurada.
+        </p>
+      </header>
+
+      <!-- Grid de tarjetas -->
+      <div class="projects-grid">
+        {
+          projects.map((p) => (
+            <article class="project-card">
+              {/* Miniatura decorativa con degradado del proyecto */}
+              <div class="project-thumb" style={`background: ${p.gradient}`} aria-hidden="true">
+                <div class="project-thumb-lines">
+                  <span />
+                  <span />
+                  <span />
+                </div>
+              </div>
+
+              <div class="project-body">
+                <p class="project-subtitle">{p.subtitle}</p>
+                <h2 class="project-title">{p.title}</h2>
+                <p class="project-desc">{p.description}</p>
+
+                {/* Stack técnico */}
+                <div class="project-tags" role="list" aria-label="Stack tecnológico">
+                  {p.tags.map((tag) => (
+                    <span class="project-tag" role="listitem">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+
+                {/* CTAs */}
+                <div class="project-links">
+                  {p.repoUrl && (
+                    <a
+                      href={p.repoUrl}
+                      class="project-link"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={`Ver repositorio de ${p.title}`}
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="currentColor"
+                        aria-hidden="true"
+                      >
+                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+                      </svg>
+                      Repositorio
+                    </a>
+                  )}
+                  {p.liveUrl && (
+                    <a
+                      href={p.liveUrl}
+                      class="project-link project-link--primary"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={`Ver demo en vivo de ${p.title}`}
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="14"
+                        height="14"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        aria-hidden="true"
+                      >
+                        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                        <polyline points="15 3 21 3 21 9" />
+                        <line x1="10" y1="14" x2="21" y2="3" />
+                      </svg>
+                      Ver en vivo
+                    </a>
+                  )}
+                </div>
+              </div>
+            </article>
+          ))
+        }
+      </div>
+
+      <!--
+        Estructura preparada para futura ampliación:
+        - Filtros por tecnología: añadir barra de filtros encima del grid
+        - Detalle de proyecto: envolver cada tarjeta con <a href={`/projects/${slug}`}>
+        - Paginación: añadir controles debajo del grid
+        - Integración con API: reemplazar `projects` con datos de getCVComplete() en EPIC 4.4
+      -->
+    </div>
+  </section>
+</MainLayout>
+
+<style>
+  .projects-page {
+    padding: 0 24px 80px;
+  }
+
+  .page-wrap {
+    max-width: 760px;
+    margin: 0 auto;
+  }
+
+  /* Cabecera de página */
+  .page-header {
+    padding: 48px 0 40px;
+    border-bottom: 2px solid var(--line);
+    margin-bottom: 40px;
+  }
+
+  .page-overline {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--blue);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin-bottom: 8px;
+    font-family: var(--font-mono);
+  }
+
+  .page-title {
+    font-size: 32px;
+    font-weight: 800;
+    color: var(--ink);
+    letter-spacing: -0.02em;
+    line-height: 1.15;
+    margin-bottom: 14px;
+  }
+
+  .page-intro {
+    font-size: 15px;
+    color: var(--ink-2);
+    line-height: 1.7;
+    max-width: 560px;
+  }
+
+  /* Grid de proyectos */
+  .projects-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+  }
+
+  /* Tarjeta de proyecto */
+  .project-card {
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    overflow: hidden;
+    box-shadow: var(--shadow-card);
+    transition: box-shadow var(--transition);
+    display: flex;
+    flex-direction: column;
+  }
+
+  .project-card:hover {
+    box-shadow: var(--shadow-card-hover);
+  }
+
+  .project-thumb {
+    aspect-ratio: 16 / 9;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+  }
+
+  .project-thumb-lines {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    opacity: 0.25;
+  }
+
+  .project-thumb-lines span {
+    display: block;
+    height: 2px;
+    background: #ffffff;
+    border-radius: 1px;
+  }
+
+  .project-thumb-lines span:nth-child(1) {
+    width: 80px;
+  }
+  .project-thumb-lines span:nth-child(2) {
+    width: 56px;
+  }
+  .project-thumb-lines span:nth-child(3) {
+    width: 68px;
+  }
+
+  .project-body {
+    padding: 20px 20px 18px;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+  }
+
+  .project-subtitle {
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--ink-3);
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    margin-bottom: 6px;
+    font-family: var(--font-mono);
+  }
+
+  .project-title {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--blue);
+    margin-bottom: 10px;
+    line-height: 1.35;
+    letter-spacing: -0.01em;
+  }
+
+  .project-desc {
+    font-size: 13.5px;
+    color: var(--ink-2);
+    line-height: 1.65;
+    margin-bottom: 14px;
+    flex: 1;
+  }
+
+  /* Tags de stack */
+  .project-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 16px;
+  }
+
+  .project-tag {
+    display: inline-block;
+    padding: 3px 10px;
+    border-radius: var(--radius-pill);
+    background: var(--soft);
+    color: var(--ink-2);
+    font-size: 12px;
+    font-weight: 600;
+    border: 1px solid var(--line);
+  }
+
+  /* CTAs */
+  .project-links {
+    display: flex;
+    gap: 10px;
+    padding-top: 14px;
+    border-top: 1px solid var(--line);
+  }
+
+  .project-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--ink-2);
+    text-decoration: none;
+    padding: 6px 14px;
+    border-radius: var(--radius-pill);
+    border: 1px solid var(--line);
+    background: var(--soft);
+    transition:
+      border-color var(--transition),
+      color var(--transition),
+      background var(--transition);
+  }
+
+  .project-link:hover {
+    border-color: var(--blue);
+    color: var(--blue);
+    background: var(--blue-soft);
+  }
+
+  .project-link--primary {
+    background: var(--blue);
+    color: #fff;
+    border-color: var(--blue);
+  }
+
+  .project-link--primary:hover {
+    background: var(--blue-2);
+    border-color: var(--blue-2);
+    color: #fff;
+  }
+
+  /* Responsive */
+  @media (max-width: 600px) {
+    .projects-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .page-title {
+      font-size: 26px;
+    }
+
+    .page-header {
+      padding: 32px 0 28px;
+      margin-bottom: 28px;
+    }
+  }
+</style>


### PR DESCRIPTION
## Descripción

Implementa la página dedicada `/projects` como parte del issue #21 (4.3.3 — Página Proyectos).

## Cambios incluidos

- **`src/pages/projects.astro`** — nueva página SSG con cabecera introductoria y grid responsive de 2 columnas
- **`src/components/common/Navigation.astro`** — el enlace "Proyectos" apunta a `/projects` en lugar del anchor `/#proyectos`
- **`src/components/home/ProjectsSection.astro`** — añadido CTA "Ver todos los proyectos →" al final del grid de la home
- **`src/config/constants.ts`** — añadida ruta `ROUTES.projects = "/projects"`
- **`src/config/seo.ts`** — añadida entrada `PAGE_SEO.projects` con metadatos básicos

## Notas

- Datos estáticos (mock) reutilizados de `ProjectsSection.astro`. La integración real con la API queda diferida a la EPIC 4.4.
- La estructura de la página deja puntos de extensión comentados para filtros, detalle por slug y paginación.
- `npm run build` y `npm run lint` pasan sin errores.

## Issues relacionados

Closes #21