### PR TITLE
feat(services): servicios API por recurso — experience, skill y education (#25)

### DIFF
--- a/src/services/api/education.service.ts
+++ b/src/services/api/education.service.ts
@@ -1,0 +1,23 @@
+import type { Education } from "@/types/cv.types";
+import { apiGet, apiPost, apiPut, apiDelete } from "./base.service";
+
+type EducationPayload = Omit<Education, "id" | "profile_id" | "created_at" | "updated_at">;
+
+export async function getEducation(): Promise<Education[]> {
+  return apiGet<Education[]>("/education");
+}
+
+export async function createEducation(data: EducationPayload): Promise<Education> {
+  return apiPost<Education>("/education", data);
+}
+
+export async function updateEducation(
+  id: string,
+  data: Partial<EducationPayload>
+): Promise<Education> {
+  return apiPut<Education>(`/education/${id}`, data);
+}
+
+export async function deleteEducation(id: string): Promise<void> {
+  return apiDelete<void>(`/education/${id}`);
+}

--- a/src/services/api/experience.service.ts
+++ b/src/services/api/experience.service.ts
@@ -1,0 +1,26 @@
+import type { WorkExperience } from "@/types/cv.types";
+import { apiGet, apiPost, apiPut, apiDelete } from "./base.service";
+
+type WorkExperiencePayload = Omit<
+  WorkExperience,
+  "id" | "profile_id" | "created_at" | "updated_at"
+>;
+
+export async function getExperiences(): Promise<WorkExperience[]> {
+  return apiGet<WorkExperience[]>("/work-experience");
+}
+
+export async function createExperience(data: WorkExperiencePayload): Promise<WorkExperience> {
+  return apiPost<WorkExperience>("/work-experience", data);
+}
+
+export async function updateExperience(
+  id: string,
+  data: Partial<WorkExperiencePayload>
+): Promise<WorkExperience> {
+  return apiPut<WorkExperience>(`/work-experience/${id}`, data);
+}
+
+export async function deleteExperience(id: string): Promise<void> {
+  return apiDelete<void>(`/work-experience/${id}`);
+}

--- a/src/services/api/skill.service.ts
+++ b/src/services/api/skill.service.ts
@@ -1,0 +1,20 @@
+import type { Skill } from "@/types/cv.types";
+import { apiGet, apiPost, apiPut, apiDelete } from "./base.service";
+
+type SkillPayload = Omit<Skill, "id" | "profile_id" | "created_at" | "updated_at">;
+
+export async function getSkills(): Promise<Skill[]> {
+  return apiGet<Skill[]>("/skills");
+}
+
+export async function createSkill(data: SkillPayload): Promise<Skill> {
+  return apiPost<Skill>("/skills", data);
+}
+
+export async function updateSkill(id: string, data: Partial<SkillPayload>): Promise<Skill> {
+  return apiPut<Skill>(`/skills/${id}`, data);
+}
+
+export async function deleteSkill(id: string): Promise<void> {
+  return apiDelete<void>(`/skills/${id}`);
+}


### PR DESCRIPTION
## Resumen

Implementa la issue [#25 — 4.4.2 Crear servicios API por recurso](https://github.com/Azfe/azfe_portfolio_astro/issues/25).

- Crea `experience.service.ts` con `getExperiences`, `createExperience`, `updateExperience`, `deleteExperience`
- Crea `skill.service.ts` con `getSkills`, `createSkill`, `updateSkill`, `deleteSkill`
- Crea `education.service.ts` con `getEducation`, `createEducation`, `updateEducation`, `deleteEducation`

Todos los servicios reutilizan los helpers `apiGet`, `apiPost`, `apiPut`, `apiDelete` de `base.service.ts`. Los tipos de payload se definen con `Omit` sobre las interfaces de `cv.types.ts`, excluyendo los campos gestionados por el backend (`id`, `profile_id`, `created_at`, `updated_at`). Las actualizaciones aceptan `Partial` del payload para permitir PUT parciales.

## Plan de pruebas

- [x] `npm run lint` — sin errores
- [x] `npm run build` — build correcto
- [x] `npm test` — 24/24 tests passing
- [x] Servicios existentes (`cv.service.ts`, `profile.service.ts`) sin cambios y verificados