### PR TITLE
feat(types): alinear tipos TypeScript con el contrato de la API

### DIFF
--- a/src/components/cv/ExperienceList.astro
+++ b/src/components/cv/ExperienceList.astro
@@ -22,7 +22,7 @@ const { experiences } = Astro.props;
               <p class="text-slate-600">{exp.company}</p>
             </div>
             <span class="text-sm whitespace-nowrap text-slate-400">
-              {formatDateRange(exp.start_date, exp.end_date, exp.is_current)}
+              {formatDateRange(exp.start_date, exp.end_date, exp.end_date === null)}
             </span>
           </div>
           {exp.description && <p class="mt-3 text-sm text-slate-600">{exp.description}</p>}

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -119,7 +119,7 @@ const data = cv
         company: e.company,
         start: e.start_date,
         end: e.end_date,
-        isCurrent: e.is_current,
+        isCurrent: e.end_date === null,
         location: "",
         description: e.description ?? "",
       })),
@@ -599,11 +599,17 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
                       ) : (
                         project.title
                       )}
-                      {project.is_ongoing && <span class="project-ongoing-badge">En curso</span>}
+                      {project.end_date === null && (
+                        <span class="project-ongoing-badge">En curso</span>
+                      )}
                     </h3>
                     <div class="xp-meta-row">
                       <span class="xp-dates-pill">
-                        {formatDateRange(project.start_date, project.end_date, project.is_ongoing)}
+                        {formatDateRange(
+                          project.start_date,
+                          project.end_date,
+                          project.end_date === null
+                        )}
                       </span>
                     </div>
                     {project.description && <p class="xp-desc">{project.description}</p>}

--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -1,3 +1,16 @@
+/** Identificador MongoDB serializado como string */
+export type ObjectId = string;
+
+/** Fecha ISO 8601 serializada como string (e.g. "2024-01-15T10:30:00") */
+export type ISODateString = string;
+
+/** Campos base presentes en todas las entidades que devuelve la API */
+export interface BaseEntity {
+  id: ObjectId;
+  created_at: ISODateString | null;
+  updated_at: ISODateString | null;
+}
+
 /** Forma del formulario de contacto */
 export interface ContactFormData {
   name: string;

--- a/src/types/cv.types.ts
+++ b/src/types/cv.types.ts
@@ -1,8 +1,10 @@
+import type { BaseEntity, ISODateString, ObjectId } from "./common.types";
+
 // ---------------------------------------------------------------------------
 // Enums (reflejan los Value Objects del dominio)
 // ---------------------------------------------------------------------------
 
-export type SkillLevel = "basic" | "intermediate" | "advanced" | "expert";
+export type SkillLevel = "basic" | "intermediate" | "advanced" | "expert" | "none";
 
 /** CEFR */
 export type LanguageProficiency = "a1" | "a2" | "b1" | "b2" | "c1" | "c2";
@@ -13,166 +15,115 @@ export type ProgrammingLanguageLevel = "basic" | "intermediate" | "advanced" | "
 // Recursos individuales
 // ---------------------------------------------------------------------------
 
-export interface Profile {
-  id: string;
+export interface Profile extends BaseEntity {
   name: string;
   headline: string;
   bio: string | null;
   location: string | null;
   avatar_url: string | null;
-  created_at: string;
-  updated_at: string;
 }
 
-export interface ContactInformation {
-  id: string;
-  profile_id: string;
+export interface ContactInformation extends BaseEntity {
   email: string;
   phone: string | null;
   linkedin: string | null;
   github: string | null;
   website: string | null;
-  created_at: string;
-  updated_at: string;
 }
 
-export interface SocialNetwork {
-  id: string;
-  profile_id: string;
+export interface SocialNetwork extends BaseEntity {
   platform: string;
   url: string;
   username: string | null;
   order_index: number;
-  created_at: string;
-  updated_at: string;
 }
 
-export interface WorkExperience {
-  id: string;
-  profile_id: string;
+export interface WorkExperience extends BaseEntity {
   role: string;
   company: string;
-  start_date: string;
-  end_date: string | null;
+  start_date: ISODateString;
+  end_date: ISODateString | null;
   description: string | null;
   responsibilities: string[];
   order_index: number;
-  is_current: boolean;
-  created_at: string;
-  updated_at: string;
 }
 
-export interface Project {
-  id: string;
-  profile_id: string;
+export interface Project extends BaseEntity {
   title: string;
   description: string;
-  start_date: string;
-  end_date: string | null;
+  start_date: ISODateString;
+  end_date: ISODateString | null;
   live_url: string | null;
   repo_url: string | null;
   technologies: string[];
   order_index: number;
-  is_ongoing: boolean;
-  created_at: string;
-  updated_at: string;
 }
 
-export interface Skill {
-  id: string;
-  profile_id: string;
+export interface Skill extends BaseEntity {
   name: string;
   category: string;
   level: SkillLevel | null;
   order_index: number;
-  created_at: string;
-  updated_at: string;
 }
 
-export interface Tool {
-  id: string;
-  profile_id: string;
+export interface Tool extends BaseEntity {
   name: string;
   category: string;
   icon_url: string | null;
   order_index: number;
-  created_at: string;
-  updated_at: string;
 }
 
-export interface Education {
-  id: string;
-  profile_id: string;
+export interface Education extends BaseEntity {
   institution: string;
   degree: string;
   field: string;
-  start_date: string;
-  end_date: string | null;
+  start_date: ISODateString;
+  end_date: ISODateString | null;
   description: string | null;
   order_index: number;
-  is_ongoing: boolean;
-  created_at: string;
-  updated_at: string;
 }
 
-export interface AdditionalTraining {
-  id: string;
-  profile_id: string;
+export interface AdditionalTraining extends BaseEntity {
   title: string;
   provider: string;
-  completion_date: string;
+  completion_date: ISODateString;
   duration: string | null;
   certificate_url: string | null;
   description: string | null;
   order_index: number;
-  created_at: string;
-  updated_at: string;
 }
 
-export interface Certification {
-  id: string;
-  profile_id: string;
+export interface Certification extends BaseEntity {
   title: string;
   issuer: string;
-  issue_date: string;
-  expiry_date: string | null;
+  issue_date: ISODateString;
+  expiry_date: ISODateString | null;
   credential_id: string | null;
   credential_url: string | null;
   order_index: number;
-  is_expired: boolean;
-  created_at: string;
-  updated_at: string;
 }
 
-export interface Language {
-  id: string;
-  profile_id: string;
+export interface Language extends BaseEntity {
   name: string;
   proficiency: LanguageProficiency | null;
   order_index: number;
-  created_at: string;
-  updated_at: string;
 }
 
-export interface ProgrammingLanguage {
-  id: string;
-  profile_id: string;
+export interface ProgrammingLanguage extends BaseEntity {
   name: string;
   level: ProgrammingLanguageLevel | null;
   order_index: number;
-  created_at: string;
-  updated_at: string;
 }
 
 export interface ContactMessage {
-  id: string;
+  id: ObjectId;
   name: string;
   email: string;
   message: string;
   status: string;
-  created_at: string;
-  read_at: string | null;
-  replied_at: string | null;
+  created_at: ISODateString;
+  read_at: ISODateString | null;
+  replied_at: ISODateString | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -191,3 +142,6 @@ export interface CompleteCV {
   additional_training: AdditionalTraining[];
   certifications: Certification[];
 }
+
+/** Alias para compatibilidad con nomenclatura orientada a la API */
+export type CVResponse = CompleteCV;


### PR DESCRIPTION
## Resumen

- Añade tipos base reutilizables en `common.types.ts`: `ObjectId`, `ISODateString` e interfaz `BaseEntity`
- Refactoriza `cv.types.ts` para que todos los recursos extiendan `BaseEntity`, eliminando duplicación de `id`/timestamps
- Elimina `profile_id` de todas las interfaces (los schemas `*Response` del backend no lo exponen)
- Elimina campos computados que no se serializan en respuesta: `is_current`, `is_ongoing`, `is_expired`
- Añade `"none"` a `SkillLevel` para alinear con el `Literal` del backend
- Expone alias `CVResponse = CompleteCV`
- `api.types.ts` sin cambios — ya refleja correctamente el contrato backend

## Plan de pruebas

- [x] `npm run build` pasa sin errores de TypeScript
- [x] `npm run lint` pasa sin errores bloqueantes
- [ ] Verificar que los servicios API existentes en `src/services/api/` compilan correctamente con los nuevos tipos

Closes #26