### PR TITLE
feat: estrategia de renderizado SSR/SSG por página (issue 4.4.4)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,22 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@astrojs/react";
 import node from "@astrojs/node";
 
+/**
+ * Render strategy summary (issue 4.4.4):
+ *
+ * output: "static" (default) — pages are pre-rendered at build time unless
+ * they explicitly opt out with `export const prerender = false`.
+ *
+ * Per-page strategy:
+ *  - /          (index.astro)    → SSG  | prerender = true  — stable landing page
+ *  - /cv        (cv.astro)       → SSR  | prerender = false — live data from backend API
+ *  - /projects  (projects.astro) → SSG  | prerender = true  — static content, first iteration
+ *  - /404       (404.astro)      → SSG  | prerender = true  — static error page
+ *
+ * The @astrojs/node adapter (standalone mode) handles SSR pages at runtime.
+ * SSG pages are served as pre-built static HTML — no server overhead.
+ */
+
 // https://astro.build/config
 export default defineConfig({
   vite: {

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -1,4 +1,19 @@
 ---
+/**
+ * Render strategy: SSR (Server-Side Rendering)
+ *
+ * Rationale (I-F-4.4.4-03):
+ * The CV page renders the developer's live curriculum from the backend API.
+ * Data must be fresh on every request so that any update in the CMS (backend)
+ * is immediately visible to visitors without a rebuild.
+ *
+ * `prerender = false` opts this page out of static generation and delegates
+ * rendering to the Node.js server adapter on every incoming request.
+ * This satisfies CU-02 ("Ver Página del CV") from the functional contract.
+ *
+ * Error handling: if the backend is unavailable, the page degrades gracefully
+ * with hardcoded fallback data and a visible notice banner — no blank page shown.
+ */
 export const prerender = false;
 
 import CVLayout from "@/layouts/CVLayout.astro";

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,4 +1,18 @@
 ---
+/**
+ * Render strategy: SSG (Static Site Generation)
+ *
+ * Rationale (I-F-4.4.4-02):
+ * The home page is a landing/presentation page. Its content is stable — it does
+ * not depend on real-time data from the backend on every request.
+ * Pre-rendering at build time maximises performance (served as a static HTML file),
+ * improves Lighthouse scores and keeps hosting simple (Vercel/Netlify edge cache).
+ *
+ * `prerender = true` is explicit here even though "static" is the project default,
+ * so the intent is self-documenting and survives future output-mode changes.
+ */
+export const prerender = true;
+
 import MainLayout from "@/layouts/MainLayout.astro";
 import Hero from "@/components/home/Hero.astro";
 import AboutCard from "@/components/home/AboutCard.astro";

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,4 +1,23 @@
 ---
+/**
+ * Render strategy: SSG (Static Site Generation)
+ *
+ * Rationale (I-F-4.4.4-04):
+ * The Projects page displays curated portfolio projects. In this first iteration
+ * the backend does not expose a dedicated /projects endpoint that is stable and
+ * ready for public consumption independently of the full /cv aggregate.
+ * Projects data is also relatively static — it changes only when a new project
+ * is added or updated by the developer, not on every visitor request.
+ *
+ * Decision: SSG with static/mock content for this iteration.
+ *
+ * Migration path: once the backend /projects endpoint is production-ready and
+ * data needs to be fresh on every request, replace `prerender = true` with
+ * `prerender = false` and fetch data via `getCVComplete()` or a dedicated
+ * `getProjects()` service call — following the same pattern as cv.astro.
+ */
+export const prerender = true;
+
 import MainLayout from "@/layouts/MainLayout.astro";
 import { PAGE_SEO } from "@/config/seo";
 


### PR DESCRIPTION
## Resumen

Implementa la estrategia de renderizado definida en la issue [#27](https://github.com/Azfe/azfe_portfolio_astro/issues/27) — **4.4.4 Render dinámico SSR/SSG**.

- `index.astro` → SSG (`prerender = true`) — página estática, máximo rendimiento
- `cv.astro` → SSR (`prerender = false`) — datos en vivo desde el backend en cada petición
- `projects.astro` → SSG (`prerender = true`) — contenido estático en esta primera iteración
- `astro.config.mjs` → JSDoc con el resumen de la estrategia completa

## Decisiones

- **Projects como SSG**: los datos de proyectos son estables y el endpoint `/projects` del backend aún no está listo de forma independiente. El path de migración a SSR queda documentado en el propio archivo.
- **Documentación en código**: las decisiones de renderizado se documentan con comentarios razonados directamente en cada página — más cercano al código y más difícil de quedar obsoleto que un documento externo.
- **`prerender = true` explícito**: aunque el modo `static` lo aplica por defecto, hacerlo explícito hace que la intención sea autodocumentada y sobrevive a cambios futuros en el `output` mode.

## Verificación

`npm run build` confirma la estrategia: `/`, `/projects` y `/404` aparecen en la lista de páginas prerenderizadas; `/cv` queda fuera (SSR servido por el adaptador Node.js).