### PR TITLE
feat(errors): capa global de manejo de errores tipada

### DIFF
--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -19,7 +19,7 @@ export const prerender = false;
 import CVLayout from "@/layouts/CVLayout.astro";
 import SkillList from "@/components/cv/SkillList.astro";
 import { getCVComplete } from "@/services/api/cv.service";
-import { ApiError } from "@/services/api/base.service";
+import { fetchPageData } from "@/utils/error-handler";
 import type {
   CompleteCV,
   Skill,
@@ -31,27 +31,18 @@ import type {
 import { formatDate, formatDateRange } from "@/utils/formatters";
 import { PAGE_SEO } from "@/config/seo";
 
+const cvResult = await fetchPageData(() => getCVComplete());
+
 let cv: CompleteCV | null = null;
 let apiError: string | null = null;
 
-try {
-  cv = await getCVComplete();
-  if (!cv?.profile) {
+if (cvResult.ok) {
+  cv = cvResult.data?.profile ? cvResult.data : null;
+  if (!cv) {
     apiError = "No se encontraron datos del CV en el servidor.";
-    cv = null;
   }
-} catch (err) {
-  if (err instanceof ApiError) {
-    if (err.code === "NETWORK_ERROR") {
-      apiError = "Backend no disponible — mostrando datos de ejemplo.";
-    } else if (err.status === 404) {
-      apiError = "No se encontraron datos del CV en el servidor.";
-    } else {
-      apiError = `Error al cargar el CV (${err.status}): ${err.message}`;
-    }
-  } else {
-    apiError = "Error inesperado al cargar el CV.";
-  }
+} else {
+  apiError = cvResult.error.userMessage;
 }
 
 // Datos de ejemplo para cuando el backend no está disponible

--- a/src/services/api/cv.service.ts
+++ b/src/services/api/cv.service.ts
@@ -7,9 +7,20 @@ export async function getCVComplete(): Promise<CompleteCV> {
 }
 
 export async function downloadCV(): Promise<Blob> {
-  const res = await fetch(`${API_URL}/cv/download`);
+  let res: Response;
+  try {
+    res = await fetch(`${API_URL}/cv/download`);
+  } catch {
+    throw new ApiError(
+      503,
+      "No se pudo conectar al servidor para descargar el CV.",
+      "NETWORK_ERROR"
+    );
+  }
+
   if (!res.ok) {
     throw new ApiError(res.status, `Error al descargar el CV: HTTP ${res.status}`);
   }
+
   return res.blob();
 }

--- a/src/types/error.types.ts
+++ b/src/types/error.types.ts
@@ -1,0 +1,103 @@
+/**
+ * error.types.ts
+ *
+ * Tipos normalizados de error para la capa frontend.
+ *
+ * Principio de diseño:
+ *  - `FrontendError` es la estructura unificada que circula por la capa de
+ *    utilidades, servicios y páginas. Ni los componentes ni las páginas
+ *    deben inspeccionar `ApiError` directamente — siempre consumen este tipo.
+ *  - `ErrorCategory` clasifica el error semánticamente (para UI y logs) sin
+ *    exponer detalles de transporte (códigos HTTP, stack traces).
+ *  - Las categorías mapean 1:1 con los casos del backend que debe cubrir el MVP:
+ *    400 → VALIDATION, 404 → NOT_FOUND, 409 → CONFLICT, 5xx → SERVER_ERROR,
+ *    fallo de red → NETWORK.
+ *
+ * Uso típico:
+ *   import type { FrontendError } from "@/types/error.types";
+ *   const err: FrontendError = normalizeError(caught);
+ *   if (err.category === "NOT_FOUND") { ... }
+ */
+
+// ---------------------------------------------------------------------------
+// Categoría semántica de error
+// ---------------------------------------------------------------------------
+
+/**
+ * Categorías de error que el frontend puede distinguir.
+ *
+ * - NETWORK    → Backend no disponible (ECONNREFUSED, timeout, etc.)
+ * - VALIDATION → Datos enviados inválidos (HTTP 400 / 422)
+ * - NOT_FOUND  → Recurso inexistente (HTTP 404)
+ * - CONFLICT   → Recurso duplicado o estado inconsistente (HTTP 409)
+ * - SERVER     → Error interno del backend (HTTP 5xx)
+ * - UNKNOWN    → Cualquier otro error no clasificable
+ */
+export type ErrorCategory =
+  | "NETWORK"
+  | "VALIDATION"
+  | "NOT_FOUND"
+  | "CONFLICT"
+  | "SERVER"
+  | "UNKNOWN";
+
+// ---------------------------------------------------------------------------
+// Estructura normalizada de error
+// ---------------------------------------------------------------------------
+
+/**
+ * Representación unificada de un error en el frontend.
+ *
+ * Toda la información necesaria para decidir qué mostrar en UI
+ * y cómo reaccionar (retry vs. mostrar mensaje permanente) está aquí.
+ */
+export interface FrontendError {
+  /** Clasificación semántica del error. */
+  category: ErrorCategory;
+
+  /**
+   * Mensaje legible para el usuario en español.
+   * Siempre presente; nunca expone detalles técnicos internos.
+   */
+  userMessage: string;
+
+  /**
+   * Código HTTP de la respuesta que originó el error, si aplica.
+   * Ausente en errores de red puros.
+   */
+  httpStatus?: number;
+
+  /**
+   * Código de error opcional del backend (ej. "VALIDATION_ERROR", "NOT_FOUND").
+   * Útil para logging o mensajes más específicos sin afectar la UI.
+   */
+  backendCode?: string;
+
+  /**
+   * Indica si el usuario puede reintentar la operación.
+   * true  → fallos de red y errores 5xx (transitorios)
+   * false → errores 4xx (precondición no cumplida, no mejorará con reintento)
+   */
+  retryable: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Resultado de operación de página SSR/SSG
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrapper que encapsula el resultado de una llamada a servicio API
+ * en el contexto de una página Astro (SSR o SSG).
+ *
+ * Permite devolver datos o un error normalizado sin usar try/catch
+ * disperso en cada página.
+ *
+ * @example
+ *   const result: PageDataResult<CompleteCV> = await fetchPageData(() => getCVComplete());
+ *   if (result.ok) {
+ *     const cv = result.data;
+ *   } else {
+ *     const err = result.error; // FrontendError
+ *   }
+ */
+export type PageDataResult<T> = { ok: true; data: T } | { ok: false; error: FrontendError };

--- a/src/utils/error-handler.test.ts
+++ b/src/utils/error-handler.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Tests para la capa centralizada de manejo de errores (error-handler.ts).
+ *
+ * Estrategia: entorno `node` (sin jsdom). Se utilizan instancias reales de
+ * `ApiError` para verificar la normalización sin mockear dependencias externas.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  httpStatusToCategory,
+  normalizeError,
+  getErrorMessage,
+  isRetryableError,
+  fetchPageData,
+} from "./error-handler";
+import { ApiError } from "@/services/api/base.service";
+import type { FrontendError } from "@/types/error.types";
+
+// ---------------------------------------------------------------------------
+// httpStatusToCategory
+// ---------------------------------------------------------------------------
+
+describe("httpStatusToCategory", () => {
+  it("devuelve VALIDATION para 400", () => {
+    expect(httpStatusToCategory(400)).toBe("VALIDATION");
+  });
+
+  it("devuelve VALIDATION para 422", () => {
+    expect(httpStatusToCategory(422)).toBe("VALIDATION");
+  });
+
+  it("devuelve NOT_FOUND para 404", () => {
+    expect(httpStatusToCategory(404)).toBe("NOT_FOUND");
+  });
+
+  it("devuelve CONFLICT para 409", () => {
+    expect(httpStatusToCategory(409)).toBe("CONFLICT");
+  });
+
+  it("devuelve SERVER para 500", () => {
+    expect(httpStatusToCategory(500)).toBe("SERVER");
+  });
+
+  it("devuelve SERVER para 503", () => {
+    expect(httpStatusToCategory(503)).toBe("SERVER");
+  });
+
+  it("devuelve UNKNOWN para 401", () => {
+    expect(httpStatusToCategory(401)).toBe("UNKNOWN");
+  });
+
+  it("devuelve UNKNOWN para 403", () => {
+    expect(httpStatusToCategory(403)).toBe("UNKNOWN");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeError — ApiError de red
+// ---------------------------------------------------------------------------
+
+describe("normalizeError — error de red (NETWORK_ERROR)", () => {
+  it("produce categoría NETWORK", () => {
+    const err = new ApiError(503, "No se pudo conectar", "NETWORK_ERROR");
+    const fe = normalizeError(err);
+    expect(fe.category).toBe("NETWORK");
+  });
+
+  it("es retryable", () => {
+    const err = new ApiError(503, "No se pudo conectar", "NETWORK_ERROR");
+    expect(normalizeError(err).retryable).toBe(true);
+  });
+
+  it("incluye httpStatus y backendCode", () => {
+    const err = new ApiError(503, "No se pudo conectar", "NETWORK_ERROR");
+    const fe = normalizeError(err);
+    expect(fe.httpStatus).toBe(503);
+    expect(fe.backendCode).toBe("NETWORK_ERROR");
+  });
+
+  it("userMessage no está vacío", () => {
+    const err = new ApiError(503, "No se pudo conectar", "NETWORK_ERROR");
+    expect(normalizeError(err).userMessage.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeError — errores HTTP
+// ---------------------------------------------------------------------------
+
+describe("normalizeError — HTTP 400", () => {
+  it("produce categoría VALIDATION", () => {
+    const err = new ApiError(400, "Validation failed");
+    expect(normalizeError(err).category).toBe("VALIDATION");
+  });
+
+  it("no es retryable", () => {
+    const err = new ApiError(400, "Validation failed");
+    expect(normalizeError(err).retryable).toBe(false);
+  });
+
+  it("usa el mensaje del backend si es legible", () => {
+    const err = new ApiError(400, "El email ya existe");
+    expect(normalizeError(err).userMessage).toBe("El email ya existe");
+  });
+
+  it("usa mensaje por categoría cuando el backend envía 'HTTP 400'", () => {
+    const err = new ApiError(400, "HTTP 400");
+    const fe = normalizeError(err);
+    expect(fe.userMessage).not.toBe("HTTP 400");
+    expect(fe.userMessage.length).toBeGreaterThan(0);
+  });
+});
+
+describe("normalizeError — HTTP 404", () => {
+  it("produce categoría NOT_FOUND", () => {
+    const err = new ApiError(404, "Profile not found");
+    expect(normalizeError(err).category).toBe("NOT_FOUND");
+  });
+
+  it("no es retryable", () => {
+    const err = new ApiError(404, "Profile not found");
+    expect(normalizeError(err).retryable).toBe(false);
+  });
+});
+
+describe("normalizeError — HTTP 409", () => {
+  it("produce categoría CONFLICT", () => {
+    const err = new ApiError(409, "Duplicate entry");
+    expect(normalizeError(err).category).toBe("CONFLICT");
+  });
+
+  it("no es retryable", () => {
+    const err = new ApiError(409, "Duplicate entry");
+    expect(normalizeError(err).retryable).toBe(false);
+  });
+});
+
+describe("normalizeError — HTTP 500", () => {
+  it("produce categoría SERVER", () => {
+    const err = new ApiError(500, "Internal server error");
+    expect(normalizeError(err).category).toBe("SERVER");
+  });
+
+  it("es retryable", () => {
+    const err = new ApiError(500, "Internal server error");
+    expect(normalizeError(err).retryable).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeError — Error nativo y valores desconocidos
+// ---------------------------------------------------------------------------
+
+describe("normalizeError — Error nativo", () => {
+  it("produce categoría UNKNOWN", () => {
+    expect(normalizeError(new Error("something went wrong")).category).toBe("UNKNOWN");
+  });
+
+  it("no es retryable", () => {
+    expect(normalizeError(new Error("something")).retryable).toBe(false);
+  });
+});
+
+describe("normalizeError — valor desconocido", () => {
+  it("maneja string lanzado", () => {
+    expect(normalizeError("error string").category).toBe("UNKNOWN");
+  });
+
+  it("maneja null lanzado", () => {
+    expect(normalizeError(null).category).toBe("UNKNOWN");
+  });
+
+  it("maneja undefined lanzado", () => {
+    expect(normalizeError(undefined).category).toBe("UNKNOWN");
+  });
+
+  it("maneja objeto plano lanzado", () => {
+    expect(normalizeError({ code: 42 }).category).toBe("UNKNOWN");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getErrorMessage
+// ---------------------------------------------------------------------------
+
+describe("getErrorMessage", () => {
+  it("acepta un FrontendError ya normalizado", () => {
+    const fe: FrontendError = {
+      category: "NOT_FOUND",
+      userMessage: "No se encontraron datos.",
+      retryable: false,
+    };
+    expect(getErrorMessage(fe)).toBe("No se encontraron datos.");
+  });
+
+  it("acepta un ApiError directamente y devuelve mensaje legible", () => {
+    const err = new ApiError(404, "Profile not found");
+    const msg = getErrorMessage(err);
+    expect(typeof msg).toBe("string");
+    expect(msg.length).toBeGreaterThan(0);
+  });
+
+  it("acepta un Error nativo", () => {
+    const msg = getErrorMessage(new Error("boom"));
+    expect(typeof msg).toBe("string");
+    expect(msg.length).toBeGreaterThan(0);
+  });
+
+  it("acepta null", () => {
+    const msg = getErrorMessage(null);
+    expect(typeof msg).toBe("string");
+    expect(msg.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isRetryableError
+// ---------------------------------------------------------------------------
+
+describe("isRetryableError", () => {
+  it("devuelve true para ApiError de red", () => {
+    expect(isRetryableError(new ApiError(503, "net", "NETWORK_ERROR"))).toBe(true);
+  });
+
+  it("devuelve true para ApiError 500", () => {
+    expect(isRetryableError(new ApiError(500, "server error"))).toBe(true);
+  });
+
+  it("devuelve false para ApiError 400", () => {
+    expect(isRetryableError(new ApiError(400, "bad request"))).toBe(false);
+  });
+
+  it("devuelve false para ApiError 404", () => {
+    expect(isRetryableError(new ApiError(404, "not found"))).toBe(false);
+  });
+
+  it("acepta un FrontendError ya normalizado", () => {
+    const fe: FrontendError = {
+      category: "SERVER",
+      userMessage: "Error del servidor.",
+      retryable: true,
+    };
+    expect(isRetryableError(fe)).toBe(true);
+  });
+
+  it("devuelve false para errores desconocidos", () => {
+    expect(isRetryableError(new Error("generic"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchPageData
+// ---------------------------------------------------------------------------
+
+describe("fetchPageData", () => {
+  it("devuelve { ok: true, data } cuando el fetcher resuelve", async () => {
+    const result = await fetchPageData(() => Promise.resolve({ id: "1", name: "Alex" }));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual({ id: "1", name: "Alex" });
+    }
+  });
+
+  it("devuelve { ok: false, error } cuando el fetcher lanza ApiError", async () => {
+    const result = await fetchPageData(() =>
+      Promise.reject(new ApiError(404, "Profile not found"))
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.category).toBe("NOT_FOUND");
+      expect(result.error.retryable).toBe(false);
+    }
+  });
+
+  it("devuelve { ok: false, error } con categoría NETWORK cuando el fetcher lanza NETWORK_ERROR", async () => {
+    const result = await fetchPageData(() =>
+      Promise.reject(new ApiError(503, "No se pudo conectar", "NETWORK_ERROR"))
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.category).toBe("NETWORK");
+      expect(result.error.retryable).toBe(true);
+    }
+  });
+
+  it("devuelve { ok: false, error } cuando el fetcher lanza un Error nativo", async () => {
+    const result = await fetchPageData(() => Promise.reject(new Error("unexpected")));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.category).toBe("UNKNOWN");
+    }
+  });
+
+  it("nunca lanza — siempre resuelve", async () => {
+    await expect(
+      fetchPageData(() => Promise.reject(new ApiError(500, "boom")))
+    ).resolves.toBeDefined();
+  });
+});

--- a/src/utils/error-handler.ts
+++ b/src/utils/error-handler.ts
@@ -1,37 +1,211 @@
+/**
+ * error-handler.ts
+ *
+ * Capa centralizada de manejo de errores del frontend.
+ *
+ * Responsabilidades:
+ *  1. Normalizar cualquier valor lanzado (ApiError, Error nativo, desconocido)
+ *     en un `FrontendError` tipado y consistente.
+ *  2. Mapear códigos HTTP a categorías semánticas y mensajes de usuario en español.
+ *  3. Proveer helpers para que las páginas SSR/SSG consuman servicios API
+ *     sin dispersar try/catch con lógica duplicada.
+ *
+ * Lo que NO hace este módulo:
+ *  - No contiene lógica de vista (no sabe de componentes ni de DOM).
+ *  - No accede a la red ni a servicios externos.
+ *  - No gestiona estado de aplicación (no conoce stores ni contextos React).
+ *
+ * Uso básico en una página SSR:
+ *   import { fetchPageData } from "@/utils/error-handler";
+ *   const result = await fetchPageData(() => getCVComplete());
+ *   if (!result.ok) console.error(result.error.userMessage);
+ *
+ * Uso en un componente isla React:
+ *   import { normalizeError, getErrorMessage } from "@/utils/error-handler";
+ *   catch (err) {
+ *     setError(normalizeError(err));
+ *   }
+ */
+
 import { ApiError } from "@/services/api/base.service";
+import type { FrontendError, ErrorCategory, PageDataResult } from "@/types/error.types";
+
+// ---------------------------------------------------------------------------
+// Mensajes de usuario por categoría
+// ---------------------------------------------------------------------------
+
+const CATEGORY_MESSAGES: Record<ErrorCategory, string> = {
+  NETWORK:
+    "El servidor no está disponible en este momento. Comprueba tu conexión e inténtalo de nuevo.",
+  VALIDATION: "Los datos enviados no son válidos. Revisa el formulario e inténtalo de nuevo.",
+  NOT_FOUND: "No se encontraron los datos solicitados.",
+  CONFLICT: "Ya existe un recurso con esos datos. Revisa la información e inténtalo de nuevo.",
+  SERVER: "Ha ocurrido un error interno en el servidor. Inténtalo de nuevo más tarde.",
+  UNKNOWN: "Ocurrió un error inesperado. Inténtalo de nuevo más tarde.",
+};
+
+// ---------------------------------------------------------------------------
+// Mapeo HTTP → categoría
+// ---------------------------------------------------------------------------
 
 /**
- * Transforma cualquier error capturado en un mensaje legible para el usuario.
- * Centraliza la lógica de manejo de errores de API en un único lugar.
+ * Convierte un código de estado HTTP en la categoría semántica correspondiente.
+ *
+ * Cubre los casos del contrato definido en la issue 4.4.5:
+ *   400 / 422 → VALIDATION
+ *   404       → NOT_FOUND
+ *   409       → CONFLICT
+ *   5xx       → SERVER
+ *   otros 4xx → UNKNOWN
  */
-export function getErrorMessage(err: unknown): string {
+export function httpStatusToCategory(status: number): ErrorCategory {
+  if (status === 400 || status === 422) return "VALIDATION";
+  if (status === 404) return "NOT_FOUND";
+  if (status === 409) return "CONFLICT";
+  if (status >= 500) return "SERVER";
+  return "UNKNOWN";
+}
+
+// ---------------------------------------------------------------------------
+// Normalización central
+// ---------------------------------------------------------------------------
+
+/**
+ * Transforma cualquier valor capturado en un `catch` en un `FrontendError`
+ * normalizado y tipado.
+ *
+ * Soporta:
+ *  - `ApiError` (lanzado por `apiFetch` / `base.service.ts`)
+ *  - `Error` nativo
+ *  - Cualquier otro valor (string, objeto, null, …)
+ *
+ * @param err - El valor capturado en el bloque catch.
+ * @returns   - Un `FrontendError` siempre definido, nunca lanza.
+ *
+ * @example
+ *   try { await getCVComplete(); }
+ *   catch (err) { const fe = normalizeError(err); }
+ */
+export function normalizeError(err: unknown): FrontendError {
   if (err instanceof ApiError) {
+    // Error de red: backend no disponible
     if (err.code === "NETWORK_ERROR") {
-      return "El servidor no está disponible en este momento. Inténtalo de nuevo más tarde.";
+      return {
+        category: "NETWORK",
+        userMessage: CATEGORY_MESSAGES.NETWORK,
+        httpStatus: err.status,
+        backendCode: err.code,
+        retryable: true,
+      };
     }
-    if (err.status === 404) {
-      return "No se encontraron los datos solicitados.";
-    }
-    if (err.status === 503) {
-      return "El servicio no está disponible temporalmente. Inténtalo de nuevo más tarde.";
-    }
-    return `Error ${err.status}: ${err.message}`;
+
+    const category = httpStatusToCategory(err.status);
+
+    // Para errores del backend, preferimos el mensaje del backend si es legible,
+    // pero caemos al mensaje por categoría si el backend no envió uno útil.
+    const backendMessage = err.message && !err.message.startsWith("HTTP ") ? err.message : null;
+    const userMessage = backendMessage ?? CATEGORY_MESSAGES[category];
+
+    return {
+      category,
+      userMessage,
+      httpStatus: err.status,
+      backendCode: err.code,
+      retryable: category === "SERVER" || category === "NETWORK",
+    };
   }
 
   if (err instanceof Error) {
-    return err.message;
+    return {
+      category: "UNKNOWN",
+      userMessage: CATEGORY_MESSAGES.UNKNOWN,
+      retryable: false,
+    };
   }
 
-  return "Ocurrió un error inesperado.";
+  return {
+    category: "UNKNOWN",
+    userMessage: CATEGORY_MESSAGES.UNKNOWN,
+    retryable: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers de presentación
+// ---------------------------------------------------------------------------
+
+/**
+ * Devuelve el mensaje de error listo para mostrarse en la UI.
+ *
+ * Acepta tanto un `FrontendError` ya normalizado como cualquier valor
+ * capturado en un catch (para uso directo sin normalizar antes).
+ *
+ * @example
+ *   // Con FrontendError ya normalizado
+ *   const msg = getErrorMessage(normalizeError(err));
+ *
+ *   // Directamente desde catch
+ *   const msg = getErrorMessage(err);
+ */
+export function getErrorMessage(err: unknown): string {
+  if (err !== null && typeof err === "object" && "category" in err && "userMessage" in err) {
+    // Es un FrontendError ya normalizado
+    return (err as FrontendError).userMessage;
+  }
+
+  return normalizeError(err).userMessage;
 }
 
 /**
- * Determina si un error es recuperable (puede reintentar el usuario)
- * o permanente (no tiene sentido reintentar).
+ * Determina si el error es recuperable (el usuario puede reintentar).
+ *
+ * - `true`  → errores de red y errores de servidor (5xx), son transitorios.
+ * - `false` → errores de cliente (4xx), no mejoran con reintentos.
+ *
+ * @example
+ *   if (isRetryableError(err)) showRetryButton();
  */
 export function isRetryableError(err: unknown): boolean {
-  if (err instanceof ApiError) {
-    return err.status >= 500 || err.code === "NETWORK_ERROR";
+  if (err !== null && typeof err === "object" && "retryable" in err) {
+    // Es un FrontendError ya normalizado
+    return Boolean((err as FrontendError).retryable);
   }
-  return false;
+
+  return normalizeError(err).retryable;
+}
+
+// ---------------------------------------------------------------------------
+// Helper para páginas SSR / SSG
+// ---------------------------------------------------------------------------
+
+/**
+ * Envuelve una llamada a servicio API para uso en el frontmatter de páginas
+ * Astro (SSR o SSG). Elimina la necesidad de bloques try/catch repetidos.
+ *
+ * Devuelve un `PageDataResult<T>`:
+ *  - `{ ok: true, data: T }` en caso de éxito
+ *  - `{ ok: false, error: FrontendError }` en caso de fallo
+ *
+ * La página decide cómo reaccionar: mostrar fallback, redirigir a 404,
+ * mostrar banner de error, etc.
+ *
+ * @param fetcher - Función asíncrona que llama al servicio API.
+ * @returns       - `PageDataResult<T>` siempre resuelto, nunca lanza.
+ *
+ * @example
+ *   // En cv.astro (SSR)
+ *   const result = await fetchPageData(() => getCVComplete());
+ *   if (result.ok) {
+ *     const cv = result.data;
+ *   } else {
+ *     const errorMsg = result.error.userMessage;
+ *   }
+ */
+export async function fetchPageData<T>(fetcher: () => Promise<T>): Promise<PageDataResult<T>> {
+  try {
+    const data = await fetcher();
+    return { ok: true, data };
+  } catch (err) {
+    return { ok: false, error: normalizeError(err) };
+  }
 }


### PR DESCRIPTION
## Resumen

- Introduce los tipos `FrontendError`, `ErrorCategory` y `PageDataResult<T>` en `src/types/error.types.ts`
- Reescribe `src/utils/error-handler.ts` con cinco funciones públicas: `httpStatusToCategory`, `normalizeError`, `getErrorMessage`, `isRetryableError` y `fetchPageData<T>`
- Actualiza `src/pages/cv.astro` para usar `fetchPageData()`, eliminando el bloque try/catch con múltiples ramas `instanceof ApiError`
- Actualiza `src/services/api/cv.service.ts` para que `downloadCV()` lance `ApiError` tipado en errores de red

## Plan de pruebas

- [ ] Ejecutar `npm test` y verificar que los 67 tests de `error-handler.test.ts` pasan en verde
- [ ] Verificar que `npm run build` completa sin errores de TypeScript
- [ ] Navegar a `/cv` con la API activa y comprobar que los datos cargan correctamente
- [ ] Navegar a `/cv` con la API apagada y comprobar que se muestra el mensaje de error esperado

Closes #28