### PR TITLE
feat(cv): reemplazar window.print() por DownloadButton island con fetch al backend

### DIFF
--- a/src/components-islands/DownloadButton.test.ts
+++ b/src/components-islands/DownloadButton.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests para DownloadButton.
+ *
+ * Entorno: node (sin jsdom). El componente React en sí requiere DOM para
+ * renderizarse, por lo que no se prueba el JSX directamente.
+ *
+ * Qué se cubre:
+ *  - La función pura `downloadPdf` exportada — lógica de red y validación.
+ *  - El módulo exporta el componente por defecto y la función auxiliar.
+ *
+ * Qué no se cubre aquí:
+ *  - El ciclo de useState/eventos DOM del botón (requiere jsdom o
+ *    react-testing-library, fuera del alcance de este entorno node).
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { downloadPdf } from "./DownloadButton";
+
+// ---------------------------------------------------------------------------
+// Helpers para mockear fetch
+// ---------------------------------------------------------------------------
+
+function makeFetchMock(options: {
+  ok: boolean;
+  status?: number;
+  contentType?: string;
+  blob?: Blob;
+}): typeof fetch {
+  const { ok, status = ok ? 200 : 500, contentType = "application/pdf", blob } = options;
+
+  return vi.fn().mockResolvedValue({
+    ok,
+    status,
+    headers: {
+      get: (name: string) => (name === "content-type" ? contentType : null),
+    },
+    blob: () => Promise.resolve(blob ?? new Blob(["PDF content"], { type: "application/pdf" })),
+  } as unknown as Response);
+}
+
+// ---------------------------------------------------------------------------
+// Módulo — comprobación de exports
+// ---------------------------------------------------------------------------
+
+describe("DownloadButton — módulo exports", () => {
+  it("exporta una función downloadPdf", () => {
+    expect(typeof downloadPdf).toBe("function");
+  });
+
+  it("exporta el componente React por defecto", async () => {
+    const mod = await import("./DownloadButton");
+    expect(typeof mod.default).toBe("function");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// downloadPdf — respuesta exitosa
+// ---------------------------------------------------------------------------
+
+describe("downloadPdf — respuesta exitosa", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("resuelve sin lanzar cuando el fetch devuelve un PDF válido", async () => {
+    // En node no existe URL.createObjectURL ni document; mockeamos lo
+    // estrictamente necesario para que la función no explote en node.
+    vi.stubGlobal("fetch", makeFetchMock({ ok: true, contentType: "application/pdf" }));
+    vi.stubGlobal("URL", {
+      createObjectURL: vi.fn().mockReturnValue("blob:fake-url"),
+      revokeObjectURL: vi.fn(),
+    });
+    vi.stubGlobal("document", {
+      createElement: vi.fn().mockReturnValue({
+        href: "",
+        download: "",
+        click: vi.fn(),
+      }),
+      body: {
+        appendChild: vi.fn(),
+        removeChild: vi.fn(),
+      },
+    });
+    vi.stubGlobal("setTimeout", vi.fn());
+
+    await expect(
+      downloadPdf("http://localhost:8000/api/v1/cv/download", "cv.pdf")
+    ).resolves.toBeUndefined();
+  });
+
+  it("también acepta content-type octet-stream", async () => {
+    vi.stubGlobal("fetch", makeFetchMock({ ok: true, contentType: "application/octet-stream" }));
+    vi.stubGlobal("URL", {
+      createObjectURL: vi.fn().mockReturnValue("blob:fake-url"),
+      revokeObjectURL: vi.fn(),
+    });
+    vi.stubGlobal("document", {
+      createElement: vi.fn().mockReturnValue({ href: "", download: "", click: vi.fn() }),
+      body: { appendChild: vi.fn(), removeChild: vi.fn() },
+    });
+    vi.stubGlobal("setTimeout", vi.fn());
+
+    await expect(
+      downloadPdf("http://localhost:8000/api/v1/cv/download", "cv.pdf")
+    ).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// downloadPdf — errores HTTP
+// ---------------------------------------------------------------------------
+
+describe("downloadPdf — errores HTTP", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("lanza Error con el status cuando la respuesta no es ok (500)", async () => {
+    vi.stubGlobal("fetch", makeFetchMock({ ok: false, status: 500 }));
+
+    await expect(downloadPdf("http://localhost:8000/api/v1/cv/download", "cv.pdf")).rejects.toThrow(
+      "HTTP 500"
+    );
+  });
+
+  it("lanza Error con el status cuando la respuesta no es ok (404)", async () => {
+    vi.stubGlobal("fetch", makeFetchMock({ ok: false, status: 404 }));
+
+    await expect(downloadPdf("http://localhost:8000/api/v1/cv/download", "cv.pdf")).rejects.toThrow(
+      "HTTP 404"
+    );
+  });
+
+  it("lanza Error cuando el content-type no es PDF ni octet-stream", async () => {
+    vi.stubGlobal("fetch", makeFetchMock({ ok: true, contentType: "application/json" }));
+
+    await expect(downloadPdf("http://localhost:8000/api/v1/cv/download", "cv.pdf")).rejects.toThrow(
+      "no es un PDF válido"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// downloadPdf — errores de red
+// ---------------------------------------------------------------------------
+
+describe("downloadPdf — errores de red", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("propagates network errors thrown by fetch", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
+
+    await expect(downloadPdf("http://localhost:8000/api/v1/cv/download", "cv.pdf")).rejects.toThrow(
+      "Failed to fetch"
+    );
+  });
+});

--- a/src/components-islands/DownloadButton.tsx
+++ b/src/components-islands/DownloadButton.tsx
@@ -1,0 +1,205 @@
+/**
+ * DownloadButton.tsx
+ *
+ * Componente isla React que descarga el CV en PDF desde el backend.
+ * Recibe la URL del PDF como prop `href` para evitar acoplamientos con la
+ * configuración de la API dentro del componente.
+ *
+ * Comportamiento:
+ *  - Realiza un fetch al endpoint indicado y crea un object URL temporal.
+ *  - Dispara la descarga del archivo con el nombre "cv-alex-zapata.pdf".
+ *  - Muestra un estado de carga visual (spinner + texto) mientras procesa.
+ *  - Muestra un mensaje de error inline si la descarga falla.
+ *
+ * Estilos: inline exclusivamente (sin Tailwind). El aspecto replica el de
+ * `.cv-download-btn` definido en CVLayout.astro.
+ */
+
+import { useState } from "react";
+
+// ---------------------------------------------------------------------------
+// Utilidad pura exportada — testeable en entorno node
+// ---------------------------------------------------------------------------
+
+/**
+ * Descarga el PDF desde `href` y lo ofrece al usuario con `filename`.
+ * Retorna void en éxito o lanza un Error con mensaje legible en fallo.
+ *
+ * Se exporta para permitir tests unitarios de la lógica sin DOM.
+ */
+export async function downloadPdf(href: string, filename: string): Promise<void> {
+  const res = await fetch(href);
+
+  if (!res.ok) {
+    throw new Error(`No se pudo descargar el CV (HTTP ${res.status})`);
+  }
+
+  const contentType = res.headers.get("content-type") ?? "";
+  if (!contentType.includes("pdf") && !contentType.includes("octet-stream")) {
+    // La respuesta no parece un PDF — podría ser un error envuelto en JSON
+    throw new Error("La respuesta del servidor no es un PDF válido");
+  }
+
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+
+  // Liberar la URL de objeto una vez que el navegador inicia la descarga
+  setTimeout(() => URL.revokeObjectURL(url), 10_000);
+}
+
+// ---------------------------------------------------------------------------
+// Estilos inline
+// ---------------------------------------------------------------------------
+
+const BASE_STYLE: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "6px",
+  padding: "7px 16px",
+  borderRadius: "999px",
+  fontSize: "12px",
+  fontWeight: 700,
+  letterSpacing: "0.06em",
+  color: "#ffffff",
+  background: "#00507d",
+  border: "none",
+  cursor: "pointer",
+  textTransform: "uppercase",
+  transition: "background 200ms ease",
+  userSelect: "none",
+};
+
+const LOADING_STYLE: React.CSSProperties = {
+  ...BASE_STYLE,
+  cursor: "default",
+  opacity: 0.8,
+};
+
+const ERROR_STYLE: React.CSSProperties = {
+  display: "block",
+  marginTop: "4px",
+  fontSize: "11px",
+  color: "#c0392b",
+  fontWeight: 500,
+};
+
+// ---------------------------------------------------------------------------
+// Icono SVG — download (misma figura que en CVLayout.astro)
+// ---------------------------------------------------------------------------
+
+function DownloadIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="7 10 12 15 17 10" />
+      <line x1="12" y1="15" x2="12" y2="3" />
+    </svg>
+  );
+}
+
+// Spinner minimalista en SVG para el estado de carga
+function Spinner() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      aria-hidden="true"
+      style={{ animation: "spin 0.8s linear infinite" }}
+    >
+      <circle cx="12" cy="12" r="10" opacity="0.25" />
+      <path d="M12 2a10 10 0 0 1 10 10" />
+      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface DownloadButtonProps {
+  /** URL completa del endpoint que devuelve el PDF. */
+  href: string;
+  /** Texto del botón. Por defecto "Descargar CV". */
+  label?: string;
+  /** Nombre sugerido para el archivo descargado. */
+  filename?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Componente principal
+// ---------------------------------------------------------------------------
+
+export default function DownloadButton({
+  href,
+  label = "Descargar CV",
+  filename = "cv-alex-zapata.pdf",
+}: DownloadButtonProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleClick = async () => {
+    if (loading) return;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      await downloadPdf(href, filename);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Error desconocido al descargar el CV";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ display: "inline-block" }}>
+      <button
+        onClick={handleClick}
+        disabled={loading}
+        aria-label={loading ? "Descargando CV…" : label}
+        style={loading ? LOADING_STYLE : BASE_STYLE}
+        onMouseEnter={(e) => {
+          if (!loading) {
+            (e.currentTarget as HTMLButtonElement).style.background = "#2a78a6";
+          }
+        }}
+        onMouseLeave={(e) => {
+          if (!loading) {
+            (e.currentTarget as HTMLButtonElement).style.background = "#00507d";
+          }
+        }}
+      >
+        {loading ? <Spinner /> : <DownloadIcon />}
+        {loading ? "DESCARGANDO…" : label.toUpperCase()}
+      </button>
+      {error && <span style={ERROR_STYLE}>{error}</span>}
+    </div>
+  );
+}

--- a/src/layouts/CVLayout.astro
+++ b/src/layouts/CVLayout.astro
@@ -3,6 +3,8 @@
 // layout for CV viewing and download, with its own toolbar (back link, print/
 // download action). The standard site navigation is irrelevant in this context.
 import BaseLayout from "./BaseLayout.astro";
+import DownloadButton from "@/components-islands/DownloadButton";
+import { API_URL } from "@/config/constants";
 
 interface Props {
   title?: string;
@@ -36,22 +38,7 @@ const { title, description, noindex = false } = Astro.props;
           >
           Portfolio
         </a>
-        <button onclick="window.print()" class="cv-download-btn">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            ><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline
-              points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg
-          >
-          DESCARGAR
-        </button>
+        <DownloadButton href={`${API_URL}/cv/download`} label="Descargar CV" client:load />
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Resumen

- Crea `DownloadButton.tsx` como componente isla React en `src/components-islands/`, que descarga el CV en PDF via `fetch()` al endpoint `/api/v1/cv/download` del backend
- Reemplaza el botón estático `<button onclick="window.print()">` de `CVLayout.astro` por el nuevo componente con `client:load`
- Exporta `downloadPdf()` como función pura para facilitar tests

## Cambios

- `src/components-islands/DownloadButton.tsx` — nuevo componente React con estado de carga (spinner), manejo de errores inline y estilos inline que replican el botón anterior
- `src/components-islands/DownloadButton.test.ts` — 6 tests sobre `downloadPdf`: descarga exitosa (pdf y octet-stream), HTTP 500, HTTP 404, content-type incorrecto y error de red
- `src/layouts/CVLayout.astro` — sustituye `window.print()` por `<DownloadButton href={API_URL + "/cv/download"} client:load />`

## Plan de pruebas

- [ ] Verificar que el botón "Descargar CV" aparece en la barra superior de `/cv`
- [ ] Comprobar que al hacer clic se muestra el spinner y el texto "DESCARGANDO…"
- [ ] Comprobar que el PDF se descarga correctamente cuando el backend está disponible
- [ ] Comprobar que se muestra el mensaje de error inline si el backend no responde
- [ ] Ejecutar `npm test` y verificar que todos los tests pasan

Closes #31 