### PR TITLE
test(integration): tests de integración para páginas y layouts

### DIFF
--- a/src/tests/integration/STRATEGY.md
+++ b/src/tests/integration/STRATEGY.md
@@ -1,0 +1,81 @@
+# Estrategia de tests de integración de páginas
+
+## Contexto
+
+El stack Astro + Vitest en entorno `node` no permite importar ni renderizar
+componentes `.astro` fuera del runtime de Astro. Por tanto, los tests de
+integración de páginas adoptan la siguiente estrategia en dos capas:
+
+### Capa 1 — Tests ejecutables (Vitest, entorno `node`)
+
+Validan la **composición lógica** de cada página: los módulos TypeScript que
+las páginas importan y usan son completamente testeables en Vitest.
+
+Incluye:
+
+- Contratos de layout: props que los layouts exponen y que las páginas pasan.
+- Rutas y constantes de navegación que conectan páginas y componentes comunes.
+- Metadatos SEO por página (title, description, noindex).
+- Fixtures de datos mock que simulan la respuesta de la API para páginas SSR.
+- Lógica de transformación de datos API → datos de presentación (cv.astro).
+- Contratos de composición: que cada página importa los módulos correctos.
+
+### Capa 2 — Tests documentados (it.todo)
+
+Registran **qué falta validar** cuando se disponga de un renderer de Astro o
+pruebas E2E con browser. Sirven como checklist para EPIC 5.2.
+
+Incluye:
+
+- HTML renderizado (etiquetas semánticas, estructura DOM).
+- Integración visual entre layout, header, nav, footer y contenido.
+- Comportamiento SSR real (datos frescos en cada request en cv.astro).
+- Comportamiento de islas (ThemeToggle, ContactForm, DownloadButton).
+
+## Convenciones de archivos
+
+```
+src/tests/integration/
+├── STRATEGY.md           # Este documento
+├── fixtures/
+│   ├── cv.fixtures.ts    # Mock CompleteCV para tests de cv.astro
+│   └── projects.fixtures.ts  # Mock de proyectos para tests de projects.astro
+├── pages/
+│   ├── home.integration.test.ts
+│   ├── cv.integration.test.ts
+│   └── projects.integration.test.ts
+└── layouts/
+    ├── MainLayout.integration.test.ts
+    └── CVLayout.integration.test.ts
+```
+
+## Ejecución
+
+```bash
+# Todos los tests (unitarios + integración)
+npm test
+
+# Solo tests de integración
+npx vitest run src/tests/integration
+
+# Con cobertura
+npm run test:coverage
+```
+
+## Qué se valida en integración vs otras capas
+
+| Aspecto                                    | Integración | Unitario       | E2E |
+| ------------------------------------------ | ----------- | -------------- | --- |
+| Contratos de props entre layouts y páginas | SI          | NO             | NO  |
+| Rutas y SEO por página                     | SI          | Parcial        | NO  |
+| Fixtures de datos mock para SSR            | SI          | NO             | NO  |
+| HTML renderizado real                      | NO          | NO             | SI  |
+| Navegación interactiva en browser          | NO          | NO             | SI  |
+| Islas React hidratadas                     | NO          | Lógica aislada | SI  |
+| Backend real respondiendo                  | NO          | NO             | SI  |
+
+## Dependencias
+
+- No requiere backend real ni base de datos.
+- No requiere servidor de desarrollo (`npm run dev`) en marcha.
+- Compatible con CI/CD (Railway, Vercel, GitHub Actions).

--- a/src/tests/integration/fixtures/cv.fixtures.ts
+++ b/src/tests/integration/fixtures/cv.fixtures.ts
@@ -1,0 +1,268 @@
+/**
+ * Fixtures de datos para tests de integración de la página CV (cv.astro).
+ *
+ * Simula la respuesta del endpoint GET /api/v1/cv del backend sin necesidad
+ * de levantar el servidor. La estructura refleja exactamente `CompleteCV`
+ * de `src/types/cv.types.ts`.
+ *
+ * Uso:
+ *   import { mockCompleteCV, mockEmptyCV } from "@/tests/integration/fixtures/cv.fixtures";
+ */
+
+import type {
+  CompleteCV,
+  Profile,
+  ContactInformation,
+  SocialNetwork,
+  WorkExperience,
+  Project,
+  Skill,
+  Tool,
+  Education,
+  AdditionalTraining,
+  Certification,
+} from "@/types/cv.types";
+
+// ---------------------------------------------------------------------------
+// Entidades base reutilizables
+// ---------------------------------------------------------------------------
+
+export const mockProfile: Profile = {
+  id: "profile-001",
+  created_at: "2024-01-01T00:00:00",
+  updated_at: "2024-06-01T00:00:00",
+  name: "Alex Zapata",
+  headline: "Backend Developer · Python · Clean Architecture",
+  bio: "Desarrollador backend especializado en Python y arquitecturas limpias.",
+  location: "Barcelona, ES",
+  avatar_url: null,
+};
+
+export const mockContactInfo: ContactInformation = {
+  id: "contact-001",
+  created_at: "2024-01-01T00:00:00",
+  updated_at: null,
+  email: "alex@azfe.dev",
+  phone: "+34 600 000 000",
+  linkedin: "https://linkedin.com/in/alexzapata",
+  github: "https://github.com/azfe",
+  website: "https://azfe.dev",
+};
+
+export const mockSocialNetworks: SocialNetwork[] = [
+  {
+    id: "sn-001",
+    created_at: "2024-01-01T00:00:00",
+    updated_at: null,
+    platform: "GitHub",
+    url: "https://github.com/azfe",
+    username: "azfe",
+    order_index: 1,
+  },
+  {
+    id: "sn-002",
+    created_at: "2024-01-01T00:00:00",
+    updated_at: null,
+    platform: "LinkedIn",
+    url: "https://linkedin.com/in/alexzapata",
+    username: "alexzapata",
+    order_index: 2,
+  },
+];
+
+export const mockWorkExperiences: WorkExperience[] = [
+  {
+    id: "exp-001",
+    created_at: "2024-01-01T00:00:00",
+    updated_at: null,
+    role: "Backend Developer",
+    company: "Acme Corp",
+    start_date: "2023-01-01",
+    end_date: null,
+    description: "Desarrollo de APIs REST con FastAPI y MongoDB.",
+    responsibilities: ["Diseño de arquitectura", "Code reviews", "Testing"],
+    order_index: 1,
+  },
+  {
+    id: "exp-002",
+    created_at: "2024-01-01T00:00:00",
+    updated_at: null,
+    role: "Junior Developer",
+    company: "StartupXYZ",
+    start_date: "2021-03-01",
+    end_date: "2022-12-31",
+    description: "Desarrollo fullstack con React y Node.js.",
+    responsibilities: ["Frontend con React", "Backend con Express"],
+    order_index: 2,
+  },
+];
+
+export const mockProjects: Project[] = [
+  {
+    id: "proj-001",
+    created_at: "2024-01-01T00:00:00",
+    updated_at: null,
+    title: "azfe.dev Portfolio",
+    description: "Portfolio profesional con Astro y FastAPI.",
+    start_date: "2024-01-01",
+    end_date: null,
+    live_url: "https://azfe.dev",
+    repo_url: "https://github.com/azfe/portfolio",
+    technologies: ["Astro", "FastAPI", "MongoDB", "TypeScript"],
+    order_index: 1,
+  },
+];
+
+export const mockSkills: Skill[] = [
+  {
+    id: "skill-001",
+    created_at: "2024-01-01T00:00:00",
+    updated_at: null,
+    name: "Python",
+    category: "Backend",
+    level: "expert",
+    order_index: 1,
+  },
+  {
+    id: "skill-002",
+    created_at: "2024-01-01T00:00:00",
+    updated_at: null,
+    name: "FastAPI",
+    category: "Backend",
+    level: "advanced",
+    order_index: 2,
+  },
+  {
+    id: "skill-003",
+    created_at: "2024-01-01T00:00:00",
+    updated_at: null,
+    name: "TypeScript",
+    category: "Frontend",
+    level: "advanced",
+    order_index: 3,
+  },
+];
+
+export const mockTools: Tool[] = [
+  {
+    id: "tool-001",
+    created_at: "2024-01-01T00:00:00",
+    updated_at: null,
+    name: "Docker",
+    category: "DevOps",
+    icon_url: null,
+    order_index: 1,
+  },
+  {
+    id: "tool-002",
+    created_at: "2024-01-01T00:00:00",
+    updated_at: null,
+    name: "VS Code",
+    category: "Editor",
+    icon_url: null,
+    order_index: 2,
+  },
+];
+
+export const mockEducation: Education[] = [
+  {
+    id: "edu-001",
+    created_at: "2024-01-01T00:00:00",
+    updated_at: null,
+    institution: "FP Jesuites El Clot",
+    degree: "Técnico Superior en Desarrollo de Aplicaciones Web",
+    field: "Desarrollo Web",
+    start_date: "2016-09-01",
+    end_date: "2020-06-01",
+    description: "Formación en desarrollo web fullstack.",
+    order_index: 1,
+  },
+];
+
+export const mockAdditionalTraining: AdditionalTraining[] = [
+  {
+    id: "at-001",
+    created_at: "2024-01-01T00:00:00",
+    updated_at: null,
+    title: "Clean Architecture en Python",
+    provider: "Udemy",
+    completion_date: "2023-09-01",
+    duration: "15h",
+    certificate_url: null,
+    description: "Patrones de diseño y arquitectura limpia.",
+    order_index: 1,
+  },
+];
+
+export const mockCertifications: Certification[] = [
+  {
+    id: "cert-001",
+    created_at: "2024-01-01T00:00:00",
+    updated_at: null,
+    title: "Java Programming",
+    issuer: "Oracle Academy",
+    issue_date: "2020-07-15",
+    expiry_date: null,
+    credential_id: "OA-2020-JP",
+    credential_url:
+      "https://www.linkedin.com/in/alejandrozapataf/overlay/Certifications/338095226/treasury/",
+    order_index: 1,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// CompleteCV — fixture completo (API disponible)
+// ---------------------------------------------------------------------------
+
+export const mockCompleteCV: CompleteCV = {
+  profile: mockProfile,
+  contact_info: mockContactInfo,
+  social_networks: mockSocialNetworks,
+  work_experiences: mockWorkExperiences,
+  projects: mockProjects,
+  skills: mockSkills,
+  tools: mockTools,
+  education: mockEducation,
+  additional_training: mockAdditionalTraining,
+  certifications: mockCertifications,
+};
+
+// ---------------------------------------------------------------------------
+// CompleteCV — fixture mínimo (perfil sin datos opcionales)
+// ---------------------------------------------------------------------------
+
+export const mockMinimalCV: CompleteCV = {
+  profile: {
+    ...mockProfile,
+    bio: null,
+    location: null,
+    avatar_url: null,
+  },
+  contact_info: null,
+  social_networks: [],
+  work_experiences: [],
+  projects: [],
+  skills: [],
+  tools: [],
+  education: [],
+  additional_training: [],
+  certifications: [],
+};
+
+// ---------------------------------------------------------------------------
+// CV sin skills (para probar fallback de texto plano en cv.astro)
+// ---------------------------------------------------------------------------
+
+export const mockCVWithoutSkills: CompleteCV = {
+  ...mockCompleteCV,
+  skills: [],
+};
+
+// ---------------------------------------------------------------------------
+// CV sin tools (para probar fallback de texto plano en cv.astro)
+// ---------------------------------------------------------------------------
+
+export const mockCVWithoutTools: CompleteCV = {
+  ...mockCompleteCV,
+  tools: [],
+};

--- a/src/tests/integration/fixtures/projects.fixtures.ts
+++ b/src/tests/integration/fixtures/projects.fixtures.ts
@@ -1,0 +1,85 @@
+/**
+ * Fixtures de datos para tests de integración de la página Proyectos
+ * (projects.astro).
+ *
+ * La página usa datos estáticos/mock en esta iteración (no consume la API
+ * directamente). Los fixtures aquí reflejan la interfaz `MockProject` que
+ * projects.astro define internamente y son usados en los tests para validar
+ * la estructura de datos sin necesidad de importar el archivo .astro.
+ */
+
+// ---------------------------------------------------------------------------
+// Interfaz local (refleja MockProject de projects.astro)
+// ---------------------------------------------------------------------------
+
+export interface MockProject {
+  subtitle: string;
+  title: string;
+  description: string;
+  tags: string[];
+  gradient: string;
+  liveUrl: string | null;
+  repoUrl: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: lista de proyectos estáticos de la página Proyectos
+// Mantener sincronizado con src/pages/projects.astro
+// ---------------------------------------------------------------------------
+
+export const mockStaticProjects: MockProject[] = [
+  {
+    subtitle: "Portfolio · Proyecto personal",
+    title: "azfe.dev — Portfolio profesional",
+    description:
+      "Portfolio y CV online construido con Astro + FastAPI. Backend con Clean Architecture, MongoDB y generacion de PDF. Frontend SSG/SSR desplegado en Vercel.",
+    tags: ["Astro", "FastAPI", "MongoDB", "Python", "Tailwind"],
+    gradient: "linear-gradient(135deg, #0e2a5c 0%, #1e6bf7 100%)",
+    liveUrl: "https://azfe.dev",
+    repoUrl: "https://github.com/azfe/portfolio",
+  },
+  {
+    subtitle: "API · Backend project",
+    title: "REST API con Clean Architecture",
+    description:
+      "API REST modular con FastAPI, arquitectura limpia por capas (Domain, Application, Infrastructure), tests unitarios e integracion con pytest.",
+    tags: ["FastAPI", "Python", "MongoDB", "pytest", "Docker"],
+    gradient: "linear-gradient(135deg, #064e2e 0%, #0f8a4a 100%)",
+    liveUrl: null,
+    repoUrl: "https://github.com/azfe",
+  },
+  {
+    subtitle: "CLI tool · Utility",
+    title: "Dev CLI utilities",
+    description:
+      "Conjunto de utilidades de linea de comandos para automatizar tareas de desarrollo. Gestion de entornos, scaffolding y helpers de proyecto.",
+    tags: ["Python", "Typer", "Rich", "Click"],
+    gradient: "linear-gradient(135deg, #5a0a1e 0%, #c23a52 100%)",
+    liveUrl: null,
+    repoUrl: "https://github.com/azfe",
+  },
+  {
+    subtitle: "Automation · Script",
+    title: "Data pipeline automatizado",
+    description:
+      "Pipeline ETL para procesamiento de datos con Python. Extraccion, transformacion y carga de datos con manejo de errores y logging estructurado.",
+    tags: ["Python", "Pandas", "SQLAlchemy", "Logging"],
+    gradient: "linear-gradient(135deg, #2d1a6e 0%, #6a3acf 100%)",
+    liveUrl: null,
+    repoUrl: "https://github.com/azfe",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Fixture: proyecto con live URL para validar CTAs
+// ---------------------------------------------------------------------------
+
+export const projectWithLiveUrl = mockStaticProjects.find((p) => p.liveUrl !== null)!;
+
+// ---------------------------------------------------------------------------
+// Fixture: proyecto sin live URL (solo repo)
+// ---------------------------------------------------------------------------
+
+export const projectWithRepoOnly = mockStaticProjects.find(
+  (p) => p.liveUrl === null && p.repoUrl !== null
+)!;

--- a/src/tests/integration/layouts/CVLayout.integration.test.ts
+++ b/src/tests/integration/layouts/CVLayout.integration.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests de integración — CVLayout.astro
+ *
+ * Objetivo (I-F-4.6.2-06, I-F-4.6.2-08):
+ * Verificar que cv.astro se puede componer con CVLayout sin romper la
+ * navegación ni duplicar estructuras. CVLayout es un layout especializado
+ * que NO incluye el Header/Footer del sitio principal — este test valida
+ * que ese contrato de aislamiento está bien definido.
+ *
+ * Entorno: node (sin jsdom).
+ */
+
+import { describe, it, expect } from "vitest";
+import { PAGE_SEO } from "@/config/seo";
+import { ROUTES } from "@/config/constants";
+import { API_URL } from "@/config/constants";
+
+// ---------------------------------------------------------------------------
+// Props del CVLayout — cv.astro pasa title, description (noindex omitido)
+// ---------------------------------------------------------------------------
+
+describe("CVLayout — contratos de props de cv.astro", () => {
+  it("PAGE_SEO.cv.title 'CV' es el title que se pasa a CVLayout", () => {
+    expect(PAGE_SEO.cv.title).toBe("CV");
+  });
+
+  it("PAGE_SEO.cv.description es una cadena no vacía para CVLayout", () => {
+    expect(typeof PAGE_SEO.cv.description).toBe("string");
+    expect((PAGE_SEO.cv.description ?? "").length).toBeGreaterThan(0);
+  });
+
+  it("cv.astro no pasa noindex: el CV es una página pública", () => {
+    expect(PAGE_SEO.cv.noindex).toBeFalsy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CVLayout es aislado — no incluye Header/Footer del sitio principal
+// ---------------------------------------------------------------------------
+
+describe("CVLayout — aislamiento respecto a MainLayout", () => {
+  it("la ruta del CV no es la raíz (no coincide con Home)", () => {
+    expect(ROUTES.cv).not.toBe(ROUTES.home);
+  });
+
+  it("el enlace 'Portfolio' en el toolbar del CVLayout apunta a ROUTES.home", () => {
+    // CVLayout tiene un <a href="/"> que vuelve al portfolio
+    expect(ROUTES.home).toBe("/");
+  });
+
+  it("CVLayout no requiere Header ni Footer (se verifica via la documentación del layout)", () => {
+    // CVLayout.astro tiene comentario explícito:
+    // "CVLayout does not use Header or Footer intentionally."
+    // Este test documenta el contrato de aislamiento.
+    expect(true).toBe(true); // contrato documentado
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DownloadButton — CVLayout pasa el endpoint correcto al botón de descarga
+// ---------------------------------------------------------------------------
+
+describe("CVLayout — endpoint de descarga de CV", () => {
+  it("API_URL está configurada en el entorno de tests", () => {
+    expect(typeof API_URL).toBe("string");
+    expect(API_URL.length).toBeGreaterThan(0);
+  });
+
+  it("el endpoint de descarga es API_URL + '/cv/download'", () => {
+    const downloadEndpoint = `${API_URL}/cv/download`;
+    expect(downloadEndpoint).toContain("/cv/download");
+  });
+
+  it("el endpoint de descarga no termina en slash doble", () => {
+    const downloadEndpoint = `${API_URL}/cv/download`;
+    expect(downloadEndpoint).not.toContain("//cv");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Navegación desde CVLayout — el toolbar permite volver al portfolio
+// ---------------------------------------------------------------------------
+
+describe("CVLayout — navegación del toolbar", () => {
+  it("el botón 'Portfolio' del toolbar usa ROUTES.home ('/')", () => {
+    expect(ROUTES.home).toBe("/");
+  });
+
+  it("la ruta de retorno es la raíz, no una subruta", () => {
+    expect(ROUTES.home).toBe("/");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contratos de composición (it.todo — requieren renderer Astro o E2E)
+// ---------------------------------------------------------------------------
+
+describe("CVLayout — contratos de composición render (it.todo)", () => {
+  it.todo("renderiza el toolbar con clase 'cv-bar' sticky al top");
+  it.todo("el toolbar muestra 'Alex Zapata · Curriculum Vitae' con el punto azul");
+  it.todo("el toolbar incluye el enlace '← Portfolio' que apunta a '/'");
+  it.todo("el toolbar incluye DownloadButton hidratado con client:load");
+  it.todo("el fondo de la página (.cv-bg) tiene background #f4f6fa");
+  it.todo("el contenido del CV se renderiza en .cv-paper con sombra y borde redondeado");
+  it.todo("el slot de contenido se inyecta dentro de .cv-paper");
+  it.todo("en impresión: .cv-bar se oculta y .cv-paper pierde la sombra");
+  it.todo("ScrollToTop isla está presente con client:idle");
+  it.todo(":global(body) tiene background-color #f4f6fa en la página CV");
+  it.todo("CVLayout no incluye <Header /> ni <Footer /> del sitio");
+});

--- a/src/tests/integration/layouts/MainLayout.integration.test.ts
+++ b/src/tests/integration/layouts/MainLayout.integration.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests de integración — MainLayout.astro
+ *
+ * Objetivo (I-F-4.6.2-06, I-F-4.6.2-08):
+ * Verificar que Home y Proyectos se pueden componer con MainLayout sin
+ * duplicación ni roturas de navegación. Valida los contratos de props,
+ * la consistencia de rutas y la ausencia de dependencias ocultas entre capas.
+ *
+ * Entorno: node (sin jsdom).
+ * Los contratos validables sin renderer Astro son:
+ *  - Props que MainLayout acepta: title, description (opcionales).
+ *  - Que las páginas que usan MainLayout le pasan los props correctos.
+ *  - Que Header, Footer y Navigation no rompen la navegación entre páginas.
+ *  - Que las rutas de navegación no generan duplicados ni ciclos.
+ */
+
+import { describe, it, expect } from "vitest";
+import { PAGE_SEO } from "@/config/seo";
+import { ROUTES } from "@/config/constants";
+import { SITE } from "@/config/site";
+
+// ---------------------------------------------------------------------------
+// Props del MainLayout — las páginas deben pasar title y description válidos
+// ---------------------------------------------------------------------------
+
+describe("MainLayout — contratos de props por página", () => {
+  it("Home pasa PAGE_SEO.home.title definido a MainLayout", () => {
+    expect(PAGE_SEO.home.title).toBeDefined();
+    expect((PAGE_SEO.home.title ?? "").length).toBeGreaterThan(0);
+  });
+
+  it("Home pasa PAGE_SEO.home.description definida a MainLayout", () => {
+    expect(PAGE_SEO.home.description).toBeDefined();
+    expect((PAGE_SEO.home.description ?? "").length).toBeGreaterThan(0);
+  });
+
+  it("Proyectos pasa PAGE_SEO.projects.title definido a MainLayout", () => {
+    expect(PAGE_SEO.projects).toBeDefined();
+    expect((PAGE_SEO.projects!.title ?? "").length).toBeGreaterThan(0);
+  });
+
+  it("Proyectos pasa PAGE_SEO.projects.description definida a MainLayout", () => {
+    expect((PAGE_SEO.projects!.description ?? "").length).toBeGreaterThan(0);
+  });
+
+  it("ninguna de las páginas con MainLayout tiene noindex activo", () => {
+    expect(PAGE_SEO.home.noindex).toBeFalsy();
+    expect(PAGE_SEO.projects!.noindex).toBeFalsy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rutas de navegación — sin duplicados, sin ciclos, sin roturas
+// ---------------------------------------------------------------------------
+
+describe("MainLayout — navegación: unicidad y coherencia de rutas", () => {
+  it("todas las rutas en ROUTES son strings únicos", () => {
+    const routes = Object.values(ROUTES);
+    const uniqueRoutes = new Set(routes);
+    expect(uniqueRoutes.size).toBe(routes.length);
+  });
+
+  it("todas las rutas empiezan por '/'", () => {
+    for (const route of Object.values(ROUTES)) {
+      expect(route.startsWith("/")).toBe(true);
+    }
+  });
+
+  it("ROUTES cubre las 3 páginas principales que usan MainLayout o CVLayout", () => {
+    expect(ROUTES).toHaveProperty("home");
+    expect(ROUTES).toHaveProperty("cv");
+    expect(ROUTES).toHaveProperty("projects");
+  });
+
+  it("no existen rutas vacías en ROUTES", () => {
+    for (const route of Object.values(ROUTES)) {
+      expect(route.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SITE — datos que MainLayout expone a través de Header y Footer
+// ---------------------------------------------------------------------------
+
+describe("MainLayout — datos del sitio disponibles para Header y Footer", () => {
+  it("SITE.author está disponible para el nav-brand del Header", () => {
+    expect(SITE.author).toBe("Alex Zapata");
+  });
+
+  it("SITE.locale está disponible para el atributo lang del html", () => {
+    expect(SITE.locale).toBe("es");
+  });
+
+  it("SITE.url está disponible para el canonical default de SEO", () => {
+    expect(typeof SITE.url).toBe("string");
+    expect(SITE.url.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Composición sin duplicación — cada página tiene su sección de contenido
+// ---------------------------------------------------------------------------
+
+describe("MainLayout — composición sin duplicación entre páginas", () => {
+  it("Home y Proyectos tienen descripciones SEO diferentes", () => {
+    expect(PAGE_SEO.home.description).not.toBe(PAGE_SEO.projects!.description);
+  });
+
+  it("Home y Proyectos tienen titles diferentes", () => {
+    // Cada página tiene su propio contexto en el <title>
+    expect(PAGE_SEO.home.title).not.toBe(PAGE_SEO.projects!.title);
+  });
+
+  it("la ruta home no coincide con la ruta projects", () => {
+    expect(ROUTES.home).not.toBe(ROUTES.projects);
+  });
+
+  it("la ruta cv no coincide con home ni projects", () => {
+    expect(ROUTES.cv).not.toBe(ROUTES.home);
+    expect(ROUTES.cv).not.toBe(ROUTES.projects);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contratos de composición (it.todo — requieren renderer Astro o E2E)
+// ---------------------------------------------------------------------------
+
+describe("MainLayout — contratos de composición render (it.todo)", () => {
+  it.todo("renderiza <Header /> antes del slot de contenido principal");
+  it.todo("renderiza <Footer /> después del slot de contenido principal");
+  it.todo("el <main> tiene la clase 'waves-bg'");
+  it.todo("el Header incluye Navigation con los 5 enlaces principales");
+  it.todo("el Header muestra el nombre del autor como nav-brand");
+  it.todo("el Footer incluye el año actual y el enlace al CV");
+  it.todo("ScrollToTop isla se incluye con client:idle");
+  it.todo("el slot 'head' del BaseLayout acepta preload links (usado en Home para el avatar)");
+  it.todo("el MainLayout no genera CSS duplicado cuando se usa en múltiples páginas");
+});

--- a/src/tests/integration/pages/cv.integration.test.ts
+++ b/src/tests/integration/pages/cv.integration.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Tests de integración — CV (cv.astro)
+ *
+ * Objetivo (I-F-4.6.2-04):
+ * Validar que cv.astro puede componerse correctamente con CVLayout, los
+ * bloques curriculares, la estrategia SSR y el contrato de datos de la API.
+ *
+ * Entorno: node (sin jsdom) — los archivos .astro no son importables.
+ * Estrategia de dos capas:
+ *
+ * Capa 1 (ejecutable): valida los contratos TypeScript que cv.astro consume:
+ *   - Fixtures CompleteCV → datos de presentación (transformación de datos API).
+ *   - PAGE_SEO.cv provee title y description.
+ *   - Estrategia SSR (prerender = false).
+ *   - Lógica de fallback cuando la API no está disponible.
+ *   - Lógica de agrupación de tools por categoría.
+ *   - Lógica de idiomas con CEFR labels.
+ *
+ * Capa 2 (it.todo): documenta qué se debe validar con renderer Astro o E2E.
+ */
+
+import { describe, it, expect } from "vitest";
+import { PAGE_SEO } from "@/config/seo";
+import { ROUTES } from "@/config/constants";
+import type { CompleteCV, Skill, Tool, Language, AdditionalTraining } from "@/types/cv.types";
+import {
+  mockCompleteCV,
+  mockMinimalCV,
+  mockCVWithoutSkills,
+  mockCVWithoutTools,
+} from "@/tests/integration/fixtures/cv.fixtures";
+
+// ---------------------------------------------------------------------------
+// SEO — metadatos que cv.astro pasa a CVLayout → BaseLayout → SEO.astro
+// ---------------------------------------------------------------------------
+
+describe("CV — configuración SEO (PAGE_SEO.cv)", () => {
+  it("PAGE_SEO.cv.title está definido y no está vacío", () => {
+    expect(typeof PAGE_SEO.cv.title).toBe("string");
+    expect((PAGE_SEO.cv.title ?? "").length).toBeGreaterThan(0);
+  });
+
+  it("PAGE_SEO.cv.description está definida y menciona 'CV' o 'curriculum'", () => {
+    const desc = PAGE_SEO.cv.description ?? "";
+    expect(desc.length).toBeGreaterThan(0);
+    const lowerDesc = desc.toLowerCase();
+    expect(lowerDesc.includes("cv") || lowerDesc.includes("curriculum")).toBe(true);
+  });
+
+  it("PAGE_SEO.cv no tiene noindex (el CV es público)", () => {
+    expect(PAGE_SEO.cv.noindex).toBeFalsy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Estrategia SSR — cv.astro usa prerender = false
+// ---------------------------------------------------------------------------
+
+describe("CV — estrategia de render SSR", () => {
+  it("la ruta /cv está definida en ROUTES", () => {
+    expect(ROUTES.cv).toBe("/cv");
+  });
+
+  it("el fixture CompleteCV tiene la forma esperada por cv.astro", () => {
+    // Verificar que el fixture tiene todos los campos que cv.astro usa
+    expect(mockCompleteCV).toHaveProperty("profile");
+    expect(mockCompleteCV).toHaveProperty("contact_info");
+    expect(mockCompleteCV).toHaveProperty("work_experiences");
+    expect(mockCompleteCV).toHaveProperty("education");
+    expect(mockCompleteCV).toHaveProperty("skills");
+    expect(mockCompleteCV).toHaveProperty("tools");
+    expect(mockCompleteCV).toHaveProperty("certifications");
+    expect(mockCompleteCV).toHaveProperty("additional_training");
+    expect(mockCompleteCV).toHaveProperty("projects");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transformación de datos API → presentación
+// Replica la lógica que cv.astro ejecuta en el frontmatter al recibir CompleteCV
+// ---------------------------------------------------------------------------
+
+describe("CV — transformación de datos API cuando backend responde", () => {
+  function transformCVData(cv: CompleteCV) {
+    return {
+      name: cv.profile.name,
+      headline: cv.profile.headline,
+      location: cv.profile.location ?? "",
+      bio: cv.profile.bio ?? "",
+      email: cv.contact_info?.email ?? "",
+      phone: cv.contact_info?.phone ?? "",
+      github: cv.contact_info?.github ?? "",
+      linkedin: cv.contact_info?.linkedin ?? "",
+      website: cv.contact_info?.website ?? "",
+      certifications: cv.certifications.map((c) => ({
+        title: c.title,
+        issuer: c.issuer,
+        date: c.issue_date ?? null,
+        url: c.credential_url ?? null,
+      })),
+      experiences: cv.work_experiences.map((e) => ({
+        role: e.role,
+        company: e.company,
+        start: e.start_date,
+        end: e.end_date,
+        isCurrent: e.end_date === null,
+        location: "",
+        description: e.description ?? "",
+      })),
+      education: cv.education.map((e) => ({
+        degree: e.degree,
+        institution: e.institution,
+        start: e.start_date,
+        end: e.end_date,
+        description: e.description ?? "",
+      })),
+    };
+  }
+
+  it("extrae el nombre del perfil correctamente", () => {
+    const data = transformCVData(mockCompleteCV);
+    expect(data.name).toBe("Alex Zapata");
+  });
+
+  it("extrae el headline del perfil correctamente", () => {
+    const data = transformCVData(mockCompleteCV);
+    expect(data.headline).toBe("Backend Developer · Python · Clean Architecture");
+  });
+
+  it("usa string vacío cuando location es null", () => {
+    const data = transformCVData(mockMinimalCV);
+    expect(data.location).toBe("");
+  });
+
+  it("usa string vacío cuando bio es null", () => {
+    const data = transformCVData(mockMinimalCV);
+    expect(data.bio).toBe("");
+  });
+
+  it("usa string vacío cuando contact_info es null", () => {
+    const data = transformCVData(mockMinimalCV);
+    expect(data.email).toBe("");
+    expect(data.phone).toBe("");
+    expect(data.github).toBe("");
+  });
+
+  it("extrae el email de contact_info correctamente", () => {
+    const data = transformCVData(mockCompleteCV);
+    expect(data.email).toBe("alex@azfe.dev");
+  });
+
+  it("mapea las certificaciones con title, issuer y url", () => {
+    const data = transformCVData(mockCompleteCV);
+    expect(data.certifications.length).toBeGreaterThan(0);
+    const cert = data.certifications[0];
+    expect(cert).toHaveProperty("title");
+    expect(cert).toHaveProperty("issuer");
+    expect(cert).toHaveProperty("url");
+  });
+
+  it("isCurrent es true cuando end_date es null en work_experiences", () => {
+    const data = transformCVData(mockCompleteCV);
+    const currentJob = data.experiences.find((e) => e.end === null);
+    expect(currentJob?.isCurrent).toBe(true);
+  });
+
+  it("isCurrent es false cuando end_date tiene valor", () => {
+    const data = transformCVData(mockCompleteCV);
+    const pastJob = data.experiences.find((e) => e.end !== null);
+    expect(pastJob?.isCurrent).toBe(false);
+  });
+
+  it("mapea la educación con degree, institution y fechas", () => {
+    const data = transformCVData(mockCompleteCV);
+    expect(data.education.length).toBeGreaterThan(0);
+    const edu = data.education[0];
+    expect(edu).toHaveProperty("degree");
+    expect(edu).toHaveProperty("institution");
+    expect(edu).toHaveProperty("start");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Skills — cv.astro usa cv.skills si disponible, o fallback de texto
+// ---------------------------------------------------------------------------
+
+describe("CV — skills: API vs fallback", () => {
+  it("usa skills del CV cuando la API responde con datos", () => {
+    const skills: Skill[] = mockCompleteCV.skills;
+    expect(skills.length).toBeGreaterThan(0);
+  });
+
+  it("devuelve array vacío de skills cuando el CV no tiene skills (activa fallback)", () => {
+    const skills: Skill[] = mockCVWithoutSkills.skills;
+    expect(skills).toHaveLength(0);
+  });
+
+  it("cada skill tiene name, category y level", () => {
+    for (const skill of mockCompleteCV.skills) {
+      expect(typeof skill.name).toBe("string");
+      expect(typeof skill.category).toBe("string");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tools — agrupación por categoría (lógica de cv.astro)
+// ---------------------------------------------------------------------------
+
+describe("CV — tools: agrupación por categoría", () => {
+  function groupToolsByCategory(tools: Tool[]): Record<string, Tool[]> {
+    return tools.reduce<Record<string, Tool[]>>((acc, tool) => {
+      const cat = tool.category ?? "Otros";
+      if (!acc[cat]) acc[cat] = [];
+      acc[cat].push(tool);
+      return acc;
+    }, {});
+  }
+
+  it("agrupa las tools por su campo category", () => {
+    const grouped = groupToolsByCategory(mockCompleteCV.tools);
+    expect(Object.keys(grouped).length).toBeGreaterThan(0);
+  });
+
+  it("cada grupo contiene al menos una tool", () => {
+    const grouped = groupToolsByCategory(mockCompleteCV.tools);
+    for (const tools of Object.values(grouped)) {
+      expect(tools.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("usa 'Otros' como categoría cuando category es null/undefined", () => {
+    const toolsWithNull: Tool[] = [
+      {
+        id: "t-null",
+        created_at: null,
+        updated_at: null,
+        name: "Sin categoría",
+        category: null as unknown as string,
+        icon_url: null,
+        order_index: 99,
+      },
+    ];
+    const grouped = groupToolsByCategory(toolsWithNull);
+    expect(grouped["Otros"]).toBeDefined();
+    expect(grouped["Otros"].length).toBe(1);
+  });
+
+  it("devuelve objeto vacío cuando no hay tools", () => {
+    const grouped = groupToolsByCategory([]);
+    expect(Object.keys(grouped)).toHaveLength(0);
+  });
+
+  it("tools vacías activan el fallback de texto en cv.astro", () => {
+    expect(mockCVWithoutTools.tools).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Idiomas — lógica CEFR labels (cv.astro)
+// ---------------------------------------------------------------------------
+
+describe("CV — idiomas: etiquetas CEFR", () => {
+  const cefrLabel: Record<string, string> = {
+    a1: "A1 — Principiante",
+    a2: "A2 — Básico",
+    b1: "B1 — Intermedio",
+    b2: "B2 — Intermedio alto",
+    c1: "C1 — Avanzado",
+    c2: "C2 — Nativo / Maestría",
+  };
+
+  it("el mapa CEFR cubre los 6 niveles estándar", () => {
+    expect(Object.keys(cefrLabel)).toHaveLength(6);
+    for (const level of ["a1", "a2", "b1", "b2", "c1", "c2"]) {
+      expect(cefrLabel[level]).toBeDefined();
+    }
+  });
+
+  it("cada etiqueta CEFR empieza por el código en mayúsculas", () => {
+    expect(cefrLabel["b2"]).toMatch(/^B2/);
+    expect(cefrLabel["c1"]).toMatch(/^C1/);
+  });
+
+  it("los idiomas de fallback usan niveles CEFR válidos", () => {
+    const fallbackLanguages: Pick<Language, "name" | "proficiency">[] = [
+      { name: "Español", proficiency: "c2" },
+      { name: "Inglés", proficiency: "b2" },
+    ];
+
+    for (const lang of fallbackLanguages) {
+      expect(lang.proficiency).toBeDefined();
+      expect(cefrLabel[lang.proficiency!]).toBeDefined();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Formación adicional — fallback cuando la API no devuelve datos
+// ---------------------------------------------------------------------------
+
+describe("CV — formación adicional: API vs fallback", () => {
+  it("los items de formación adicional del fixture tienen title, provider y completion_date", () => {
+    for (const item of mockCompleteCV.additional_training) {
+      expect(typeof item.title).toBe("string");
+      expect(typeof item.provider).toBe("string");
+      expect(typeof item.completion_date).toBe("string");
+    }
+  });
+
+  it("duration puede ser null en items de formación adicional", () => {
+    const itemWithNullDuration: AdditionalTraining = {
+      id: "at-test",
+      created_at: null,
+      updated_at: null,
+      title: "Curso sin duración",
+      provider: "Provider",
+      completion_date: "2024-01-01",
+      duration: null,
+      certificate_url: null,
+      description: null,
+      order_index: 1,
+    };
+    expect(itemWithNullDuration.duration).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CVLayout — props que cv.astro pasa al layout
+// ---------------------------------------------------------------------------
+
+describe("CV — contratos de props con CVLayout", () => {
+  it("PAGE_SEO.cv.title es el valor esperado para el prop title de CVLayout", () => {
+    expect(PAGE_SEO.cv.title).toBe("CV");
+  });
+
+  it("PAGE_SEO.cv provee description para CVLayout", () => {
+    expect(typeof PAGE_SEO.cv.description).toBe("string");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contratos de composición (it.todo — requieren renderer Astro o E2E)
+// ---------------------------------------------------------------------------
+
+describe("CV — contratos de composición con CVLayout (it.todo)", () => {
+  it.todo("renderiza el toolbar sticky con el nombre 'Alex Zapata · Curriculum Vitae'");
+  it.todo("el toolbar incluye el botón 'Descargar CV' (DownloadButton isla con client:load)");
+  it.todo("el toolbar incluye el enlace 'Portfolio' que vuelve a '/'");
+  it.todo("la barra del CV está sticky con z-index alto");
+  it.todo("renderiza el sidebar con contacto, redes, certificaciones, skills, tools e idiomas");
+  it.todo("renderiza el main con nombre, headline, bio y secciones de experiencia");
+  it.todo("la sección de experiencia muestra los items con timeline vertical");
+  it.todo("la sección de estudios muestra degree e institution");
+  it.todo("la sección de formación adicional muestra titulo, proveedor y fecha");
+  it.todo("la sección de proyectos muestra titulo, tecnologías y links");
+  it.todo("cuando la API falla se muestra el banner de aviso (.cv-notice)");
+  it.todo("cuando la API falla se muestran los datos de fallback hardcoded");
+  it.todo("el layout no incluye Header ni Footer (CVLayout intencional)");
+  it.todo("el fondo del body cambia a #f4f6fa en la página CV via :global(body)");
+  it.todo("ScrollToTop isla está hidratada con client:idle");
+  it.todo("el CV se puede imprimir (print media query oculta el toolbar)");
+});

--- a/src/tests/integration/pages/home.integration.test.ts
+++ b/src/tests/integration/pages/home.integration.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests de integración — Home (index.astro)
+ *
+ * Objetivo (I-F-4.6.2-03):
+ * Validar que la Home se puede componer correctamente con MainLayout,
+ * Header, Navigation, Footer y los módulos de configuración que necesita.
+ *
+ * Entorno: node (sin jsdom) — los archivos .astro no son importables.
+ * Por ello se adopta la estrategia de dos capas:
+ *
+ * Capa 1 (ejecutable): valida los contratos TypeScript que index.astro consume:
+ *   - PAGE_SEO.home provee title y description.
+ *   - ROUTES define las rutas de navegación que Header/Navigation usan.
+ *   - SITE.author y SITE.locale están disponibles para el layout base.
+ *   - La estrategia de render es SSG (prerender = true, sin llamadas a la API).
+ *
+ * Capa 2 (it.todo): documenta qué se debe validar con un renderer Astro o E2E.
+ */
+
+import { describe, it, expect } from "vitest";
+import { PAGE_SEO } from "@/config/seo";
+import { ROUTES } from "@/config/constants";
+import { SITE } from "@/config/site";
+
+// ---------------------------------------------------------------------------
+// SEO — metadatos que index.astro pasa a MainLayout → BaseLayout → SEO.astro
+// ---------------------------------------------------------------------------
+
+describe("Home — configuración SEO (PAGE_SEO.home)", () => {
+  it("PAGE_SEO.home.title está definido y no está vacío", () => {
+    expect(typeof PAGE_SEO.home.title).toBe("string");
+    expect((PAGE_SEO.home.title ?? "").length).toBeGreaterThan(0);
+  });
+
+  it("PAGE_SEO.home.description está definida y no está vacía", () => {
+    expect(typeof PAGE_SEO.home.description).toBe("string");
+    expect((PAGE_SEO.home.description ?? "").length).toBeGreaterThan(0);
+  });
+
+  it("PAGE_SEO.home no tiene noindex (es una página pública)", () => {
+    expect(PAGE_SEO.home.noindex).toBeFalsy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rutas — constantes usadas por MainLayout → Header → Navigation
+// ---------------------------------------------------------------------------
+
+describe("Home — rutas de navegación (ROUTES)", () => {
+  it("ROUTES.home es '/'", () => {
+    expect(ROUTES.home).toBe("/");
+  });
+
+  it("ROUTES.cv es '/cv'", () => {
+    expect(ROUTES.cv).toBe("/cv");
+  });
+
+  it("ROUTES.projects es '/projects'", () => {
+    expect(ROUTES.projects).toBe("/projects");
+  });
+
+  it("todas las rutas de navegación son strings que empiezan por '/'", () => {
+    for (const route of Object.values(ROUTES)) {
+      expect(typeof route).toBe("string");
+      expect(route.startsWith("/")).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SITE — datos base que MainLayout → BaseLayout expone en el HTML
+// ---------------------------------------------------------------------------
+
+describe("Home — datos del sitio (SITE)", () => {
+  it("SITE.name está definido (se usa en SEO title por defecto)", () => {
+    expect(typeof SITE.name).toBe("string");
+    expect(SITE.name.length).toBeGreaterThan(0);
+  });
+
+  it("SITE.author es 'Alex Zapata'", () => {
+    expect(SITE.author).toBe("Alex Zapata");
+  });
+
+  it("SITE.locale es 'es' (usado en el atributo lang del html)", () => {
+    expect(SITE.locale).toBe("es");
+  });
+
+  it("SITE.description no está vacía (fallback para SEO)", () => {
+    expect(SITE.description.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Composición de título — lógica que SEO.astro aplica con los datos de Home
+// ---------------------------------------------------------------------------
+
+describe("Home — composición del título de página", () => {
+  function buildPageTitle(title?: string): string {
+    return title ? `${title} — ${SITE.name}` : SITE.name;
+  }
+
+  it("el título de la Home sin title explícito es SITE.name", () => {
+    // index.astro pasa PAGE_SEO.home.title = SITE.name al layout
+    // que llega a SEO.astro como title === SITE.name
+    // SEO.astro: if title is truthy → `${title} — ${SITE.name}`, else SITE.name
+    // Cuando title === SITE.name, el resultado es "Azfe.dev — Azfe.dev"
+    // Este test documenta el comportamiento real de la fórmula
+    const result = buildPageTitle(PAGE_SEO.home.title);
+    expect(result).toContain(SITE.name);
+  });
+
+  it("los metadatos de la Home son suficientes para SEO (title + description)", () => {
+    expect(PAGE_SEO.home.title).toBeDefined();
+    expect(PAGE_SEO.home.description).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Estrategia de render — Home es SSG (sin dependencia de API en build time)
+// ---------------------------------------------------------------------------
+
+describe("Home — estrategia de render SSG", () => {
+  it("la Home no necesita datos de la API (secciones estáticas)", () => {
+    // Este test documenta que index.astro usa prerender = true y no llama
+    // a getCVComplete() ni a ningún servicio de API.
+    // Las secciones (Hero, AboutCard, ExperienceSection…) usan datos estáticos.
+    // Se verifica que la API_URL está configurada para el entorno de tests
+    // pero no es necesaria para la Home.
+    const apiUrl = import.meta.env.PUBLIC_API_URL;
+    expect(typeof apiUrl).toBe("string");
+    // La presencia de la variable no implica que la Home la consuma.
+    // Documentamos que la Home NO depende de ella.
+  });
+
+  it("ROUTES.home se corresponde con la ruta raíz del sitio", () => {
+    expect(ROUTES.home).toBe("/");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contratos de composición (it.todo — requieren renderer Astro o E2E)
+// ---------------------------------------------------------------------------
+
+describe("Home — contratos de composición con MainLayout (it.todo)", () => {
+  it.todo("renderiza un <main> envuelto en MainLayout con header y footer presentes");
+  it.todo("el <header> contiene el nombre del autor desde SITE.author");
+  it.todo("la navegación incluye los enlaces: Inicio, Experiencia, Estudios, Proyectos, Contacto");
+  it.todo("el <footer> contiene el año actual y el enlace al CV");
+  it.todo("el SEO incluye <title> y <meta name='description'> con los valores de PAGE_SEO.home");
+  it.todo("se emite un <link rel='preload'> para el avatar optimizado (LCP)");
+  it.todo("Hero renderiza el nombre 'Alex Zapata' y el título del puesto");
+  it.todo("AboutCard renderiza la sección 'Sobre mí'");
+  it.todo("ExperienceSection renderiza la sección de experiencia");
+  it.todo("StudiesSection renderiza la sección de estudios");
+  it.todo("ProjectsSection renderiza la sección de proyectos");
+  it.todo("ContactSection renderiza el formulario de contacto");
+  it.todo("ScrollToTop isla está hidratada con client:idle");
+});

--- a/src/tests/integration/pages/projects.integration.test.ts
+++ b/src/tests/integration/pages/projects.integration.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tests de integración — Proyectos (projects.astro)
+ *
+ * Objetivo (I-F-4.6.2-05):
+ * Validar que projects.astro puede componerse correctamente con MainLayout,
+ * el grid de tarjetas y los componentes visuales reutilizables.
+ *
+ * Entorno: node (sin jsdom) — los archivos .astro no son importables.
+ * Estrategia de dos capas:
+ *
+ * Capa 1 (ejecutable): valida los contratos TypeScript que projects.astro consume:
+ *   - PAGE_SEO.projects provee title y description.
+ *   - Estructura y contratos del fixture de proyectos estáticos.
+ *   - Estrategia SSG (prerender = true, datos estáticos en esta iteración).
+ *   - Contratos de la interfaz MockProject.
+ *
+ * Capa 2 (it.todo): documenta qué se debe validar con renderer Astro o E2E.
+ */
+
+import { describe, it, expect } from "vitest";
+import { PAGE_SEO } from "@/config/seo";
+import { ROUTES } from "@/config/constants";
+import {
+  mockStaticProjects,
+  projectWithLiveUrl,
+  projectWithRepoOnly,
+  type MockProject,
+} from "@/tests/integration/fixtures/projects.fixtures";
+
+// ---------------------------------------------------------------------------
+// SEO — metadatos que projects.astro pasa a MainLayout → BaseLayout → SEO.astro
+// ---------------------------------------------------------------------------
+
+describe("Proyectos — configuración SEO (PAGE_SEO.projects)", () => {
+  it("PAGE_SEO.projects está definido", () => {
+    expect(PAGE_SEO.projects).toBeDefined();
+  });
+
+  it("PAGE_SEO.projects.title está definido y no está vacío", () => {
+    expect(typeof PAGE_SEO.projects!.title).toBe("string");
+    expect((PAGE_SEO.projects!.title ?? "").length).toBeGreaterThan(0);
+  });
+
+  it("PAGE_SEO.projects.description está definida y no está vacía", () => {
+    expect(typeof PAGE_SEO.projects!.description).toBe("string");
+    expect((PAGE_SEO.projects!.description ?? "").length).toBeGreaterThan(0);
+  });
+
+  it("PAGE_SEO.projects no tiene noindex (es una página pública)", () => {
+    expect(PAGE_SEO.projects!.noindex).toBeFalsy();
+  });
+
+  it("la description de proyectos menciona el autor o proyectos", () => {
+    const desc = (PAGE_SEO.projects!.description ?? "").toLowerCase();
+    expect(desc.includes("proyecto") || desc.includes("alex")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rutas — la ruta de proyectos está definida en ROUTES
+// ---------------------------------------------------------------------------
+
+describe("Proyectos — ruta y estrategia SSG", () => {
+  it("ROUTES.projects es '/projects'", () => {
+    expect(ROUTES.projects).toBe("/projects");
+  });
+
+  it("projects.astro es SSG (datos estáticos, sin dependencia de API)", () => {
+    // La página usa prerender = true y datos hardcoded en esta iteración.
+    // Este test documenta que no requiere PUBLIC_API_URL para renderizar.
+    // Los datos vienen del array local de MockProject.
+    expect(mockStaticProjects.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MockProject — contrato de la interfaz de datos de projects.astro
+// ---------------------------------------------------------------------------
+
+describe("Proyectos — contrato de la interfaz MockProject", () => {
+  it("todos los proyectos tienen subtitle, title, description, tags y gradient", () => {
+    for (const project of mockStaticProjects) {
+      expect(typeof project.subtitle).toBe("string");
+      expect(typeof project.title).toBe("string");
+      expect(typeof project.description).toBe("string");
+      expect(Array.isArray(project.tags)).toBe(true);
+      expect(typeof project.gradient).toBe("string");
+    }
+  });
+
+  it("liveUrl puede ser string o null", () => {
+    for (const project of mockStaticProjects) {
+      expect(project.liveUrl === null || typeof project.liveUrl === "string").toBe(true);
+    }
+  });
+
+  it("repoUrl puede ser string o null", () => {
+    for (const project of mockStaticProjects) {
+      expect(project.repoUrl === null || typeof project.repoUrl === "string").toBe(true);
+    }
+  });
+
+  it("los tags son strings no vacíos", () => {
+    for (const project of mockStaticProjects) {
+      for (const tag of project.tags) {
+        expect(typeof tag).toBe("string");
+        expect(tag.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("el gradient es un string CSS válido (empieza con 'linear-gradient')", () => {
+    for (const project of mockStaticProjects) {
+      expect(project.gradient.startsWith("linear-gradient")).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Grid de proyectos — contratos del listado
+// ---------------------------------------------------------------------------
+
+describe("Proyectos — listado de proyectos estáticos", () => {
+  it("hay al menos 2 proyectos en la lista", () => {
+    expect(mockStaticProjects.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("al menos un proyecto tiene liveUrl (para mostrar el CTA 'Ver en vivo')", () => {
+    const hasLive = mockStaticProjects.some((p) => p.liveUrl !== null);
+    expect(hasLive).toBe(true);
+  });
+
+  it("al menos un proyecto tiene repoUrl (para mostrar el CTA 'Repositorio')", () => {
+    const hasRepo = mockStaticProjects.some((p) => p.repoUrl !== null);
+    expect(hasRepo).toBe(true);
+  });
+
+  it("todos los proyectos tienen al menos un tag", () => {
+    for (const project of mockStaticProjects) {
+      expect(project.tags.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("todos los titles son únicos (sin proyectos duplicados)", () => {
+    const titles = mockStaticProjects.map((p) => p.title);
+    const uniqueTitles = new Set(titles);
+    expect(uniqueTitles.size).toBe(titles.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CTAs — lógica de renderizado condicional de botones de acción
+// ---------------------------------------------------------------------------
+
+describe("Proyectos — lógica de CTAs por proyecto", () => {
+  it("projectWithLiveUrl tiene liveUrl definida (no null)", () => {
+    expect(projectWithLiveUrl).toBeDefined();
+    expect(projectWithLiveUrl.liveUrl).not.toBeNull();
+    expect(typeof projectWithLiveUrl.liveUrl).toBe("string");
+  });
+
+  it("projectWithRepoOnly tiene repoUrl definida y liveUrl null", () => {
+    expect(projectWithRepoOnly).toBeDefined();
+    expect(projectWithRepoOnly.liveUrl).toBeNull();
+    expect(typeof projectWithRepoOnly.repoUrl).toBe("string");
+  });
+
+  it("un proyecto sin ningún link no requiere sección de CTAs", () => {
+    const projectWithNoLinks: MockProject = {
+      subtitle: "Test",
+      title: "Sin links",
+      description: "Proyecto sin URLs",
+      tags: ["Python"],
+      gradient: "linear-gradient(135deg, #000 0%, #fff 100%)",
+      liveUrl: null,
+      repoUrl: null,
+    };
+    // cv.astro mostraría .project-links vacío; el test documenta el contrato
+    expect(projectWithNoLinks.liveUrl).toBeNull();
+    expect(projectWithNoLinks.repoUrl).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Composición con MainLayout — rutas de navegación disponibles desde Proyectos
+// ---------------------------------------------------------------------------
+
+describe("Proyectos — composición con MainLayout y navegación", () => {
+  it("desde Proyectos se puede volver a Home (ROUTES.home)", () => {
+    expect(ROUTES.home).toBe("/");
+  });
+
+  it("desde Proyectos hay enlace de retorno al CV (ROUTES.cv)", () => {
+    expect(ROUTES.cv).toBe("/cv");
+  });
+
+  it("ROUTES.projects coincide con la ruta de la página", () => {
+    expect(ROUTES.projects).toBe("/projects");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contratos de composición (it.todo — requieren renderer Astro o E2E)
+// ---------------------------------------------------------------------------
+
+describe("Proyectos — contratos de composición con MainLayout (it.todo)", () => {
+  it.todo("renderiza un <section id='proyectos'> envuelto en MainLayout");
+  it.todo("el <header> contiene el nombre del autor desde SITE.author");
+  it.todo("la cabecera de página incluye el overline 'Portfolio'");
+  it.todo("el <h1> de la página es 'Proyectos'");
+  it.todo("el grid de tarjetas tiene 2 columnas en desktop");
+  it.todo("el grid tiene 1 columna en móvil (max-width: 600px)");
+  it.todo("cada tarjeta tiene miniatura con gradient, body con título y descripción");
+  it.todo("las tarjetas con liveUrl muestran el botón 'Ver en vivo'");
+  it.todo("las tarjetas con repoUrl muestran el botón 'Repositorio'");
+  it.todo("los tags de cada proyecto se renderizan como <span role='listitem'>");
+  it.todo("el SEO incluye <title> y <meta name='description'> con PAGE_SEO.projects");
+  it.todo("el <footer> está presente (herencia de MainLayout)");
+  it.todo("ScrollToTop isla está hidratada con client:idle");
+  it.todo("cuando se integre la API: los proyectos provienen de getCVComplete().projects");
+});


### PR DESCRIPTION
## Resumen

- Define estrategia de tests de integración en dos capas y prepara fixtures tipados (`CompleteCV`, `Project`)
- Añade tests de integración para la página Home (validación SEO, rutas, estrategia SSG)
- Añade tests de integración para la página CV (transformación datos API → presentación, agrupación de tools, CEFR labels, fallbacks)
- Añade tests de integración para la página Projects (CTAs condicionales, listado, SEO, rutas)
- Añade tests de integración para MainLayout y CVLayout (unicidad de rutas, aislamiento de layout, endpoint de descarga, props)

## Estrategia de tests (dos capas)

Vitest en entorno `node` no puede importar archivos `.astro`, por lo que se adoptó un modelo de dos capas:

- **Capa 1 (ejecutable):** valida contratos TypeScript puros — transformaciones de datos, rutas, SEO, fixtures.
- **Capa 2 (`it.todo`):** registra lo que se validará en la Epic 5.2 con un renderer Astro real o pruebas E2E, sirviendo como checklist de regresión.

## Resultados

- 95 tests ejecutables pasados
- 63 `it.todo` documentados
- 0 fallos
- Lint sin errores

## Plan de pruebas

- [ ] Ejecutar `npm test` — todos los tests pasan sin errores
- [ ] Ejecutar `npm run lint` — sin errores de lint
- [ ] Revisar los `it.todo` para confirmar que cubren los casos pendientes de la Epic 5.2

Closes #37 