### PR TITLE
feat: duración de experiencia laboral con badge visual — feat/7.3.2.2-work-experience-duration → develop

### DIFF
--- a/src/components/cv/ExperienceList.astro
+++ b/src/components/cv/ExperienceList.astro
@@ -22,10 +22,14 @@ const { experiences } = Astro.props;
               <h3 class="font-semibold text-slate-900">{exp.role}</h3>
               <p class="text-slate-600">{exp.company}</p>
             </div>
-            <span class="text-sm whitespace-nowrap text-slate-400">
-              {formatDateRange(exp.start_date, exp.end_date, exp.is_current)} ·{" "}
-              {formatDuration(exp.duration_months)}
-            </span>
+            <div class="flex flex-col items-end gap-1">
+              <span class="text-sm whitespace-nowrap text-slate-400">
+                {formatDateRange(exp.start_date, exp.end_date, exp.is_current)}
+              </span>
+              <span class="inline-block rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium whitespace-nowrap text-blue-600">
+                {formatDuration(exp.duration_months)}
+              </span>
+            </div>
           </div>
           {exp.description && <p class="mt-3 text-sm text-slate-600">{exp.description}</p>}
           {exp.responsibilities.length > 0 && (

--- a/src/components/home/ContactSection.astro
+++ b/src/components/home/ContactSection.astro
@@ -225,9 +225,9 @@ const services = [
     if (!form) return;
 
     const SEND_ICON =
-    '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="flex-shrink:0"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>';
+      '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="flex-shrink:0"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>';
     const SPIN_ICON =
-    '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true" style="animation:cf-spin 0.8s linear infinite;flex-shrink:0"><circle cx="12" cy="12" r="10" opacity="0.25"/><path d="M12 2a10 10 0 0 1 10 10"/></svg>';
+      '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true" style="animation:cf-spin 0.8s linear infinite;flex-shrink:0"><circle cx="12" cy="12" r="10" opacity="0.25"/><path d="M12 2a10 10 0 0 1 10 10"/></svg>';
 
     function validateEmail(v) {
       return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);

--- a/src/components/home/ExperienceSection.astro
+++ b/src/components/home/ExperienceSection.astro
@@ -178,9 +178,14 @@ const sorted = [...experiences].sort((a, b) => {
   }
 
   .xp-duration {
+    display: inline-block;
     font-size: 12px;
-    color: var(--ink-3);
+    font-weight: 500;
+    color: #2563eb;
+    background-color: #dbeafe;
     white-space: nowrap;
+    border-radius: 9999px;
+    padding: 2px 10px;
   }
 
   .xp-desc {

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -29,6 +29,7 @@ import type {
   Project,
 } from "@/types/cv.types";
 import { formatDate, formatDateRange } from "@/utils/formatters";
+import { formatDuration } from "@/utils/date.utils";
 import { PAGE_SEO } from "@/config/seo";
 
 const cvResult = await fetchPageData(() => getCVComplete());
@@ -89,6 +90,7 @@ const fallback = {
       start: "2025-11-10",
       end: null,
       isCurrent: true,
+      duration_months: null,
       location: "Barcelona, ES",
       description:
         "Líder de equipos multidisciplinarios internacionales, especializado en la gestión del ciclo de vida de desarrollo bajo metodologías ágiles. Experto en coordinar flujos de trabajo en Git, asegurar la calidad mediante Code Reviews y promover estándares de Clean Code y mentoría técnica. Stack y Capacidades Técnicas: Backend: Arquitecturas escalables con Node.js, NestJS y PostgreSQL. Frontend: Interfaces reactivas con React y Tailwind CSS. DevOps: Automatización de despliegues con Docker y GitHub Actions. Liderazgo: Gestión de proyectos desde cero (E2E), garantizando escalabilidad e innovación en entornos colaborativos de alto rendimiento.",
@@ -99,6 +101,7 @@ const fallback = {
       start: "2021-03-01",
       end: "2023-01-01",
       isCurrent: false,
+      duration_months: 22,
       location: "Barcelona, ES",
       description:
         "1. Sistema HMI para Automóviles: Desarrollo de interfaces críticas de alta precisión con enfoque en rendimiento y adaptabilidad. Programé arquitecturas de componentes pixel-perfect para múltiples resoluciones y sincronicé la UI con APIs del vehículo para visualización de datos en tiempo real (latencia cero). Optimicé microinteracciones y activos visuales, garantizando fluidez y carga instantánea en hardware embebido. 2. Intranet Corporativa: Liderazgo en el desarrollo de una biblioteca de componentes reutilizables, optimizando los tiempos de desarrollo en un 30%. Implementé interfaces accesibles (estándares WCAG) y responsivas para el 100% de la plantilla. Refactoricé la integración con APIs y optimicé el consumo de recursos de red, mejorando drásticamente la velocidad de respuesta y la consistencia visual..",
@@ -140,6 +143,7 @@ const data = cv
         start: e.start_date,
         end: e.end_date,
         isCurrent: e.end_date === null,
+        duration_months: e.duration_months,
         location: "",
         description: e.description ?? "",
       })),
@@ -546,6 +550,11 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
                       <span class="xp-dates-pill">
                         {formatDateRange(exp.start, exp.end, exp.isCurrent)}
                       </span>
+                      {exp.duration_months != null && exp.duration_months > 0 && (
+                        <span class="training-duration-pill">
+                          {formatDuration(exp.duration_months)}
+                        </span>
+                      )}
                       {exp.location && <span class="xp-location-pill">{exp.location}</span>}
                     </div>
                     {exp.description && <p class="xp-desc">{exp.description}</p>}

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -567,12 +567,15 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
                 <div class="xp-item">
                   <div class="xp-dot" />
                   <div class="xp-content">
-                    <h3 class="xp-role">{edu.degree}</h3>
+                    <h3 class="xp-role">
+                      {edu.degree}
+                      <span class="xp-company-inline"> — {edu.institution}</span>
+                    </h3>
                     <div class="xp-meta-row">
                       <span class="xp-dates-pill">
                         {formatDateRange(edu.start, edu.end, false)}
                       </span>
-                      <span class="xp-company-inline">{edu.institution}</span>
+                      {/* <span class="xp-company-inline">{edu.institution}</span> */}
                     </div>
                     {edu.description && <p class="xp-desc">{edu.description}</p>}
                   </div>
@@ -609,13 +612,16 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
                         ) : (
                           item.title
                         )}
+                        {/* <span class="xp-company"> — {item.provider}</span> */}
+                        <span class="xp-company-inline"> — {item.provider}</span>
                       </h3>
+
                       <div class="xp-meta-row">
                         <span class="xp-dates-pill">{formatDate(item.completion_date)}</span>
                         {item.duration && (
                           <span class="training-duration-pill">{item.duration}</span>
                         )}
-                        <span class="xp-company-inline">{item.provider}</span>
+                        {/* <span class="xp-company-inline">{item.provider}</span> */}
                       </div>
                       {item.description && <p class="xp-desc">{item.description}</p>}
                     </div>


### PR DESCRIPTION
## Cambios

- Badge de duración en home (ExperienceSection.astro): se añade clase .xp-duration con estilo pill azul claro (bg-blue-100 / text-blue-600 / rounded-full) para mostrar los meses de cada experiencia.
- Badge de duración en CV (cv.astro + ExperienceList.astro): se preserva el campo duration_months en el mapeo de datos (antes se descartaba silenciosamente) y se renderiza condicionalmente usando la misma clase training-duration-pill ya existente en la sección de formación adicional. Visualmente idéntico.
- Formato de instituciones: las instituciones se muestran seguidas del título de cada apartado para mejorar la legibilidad.

## QA

- Badge visible en home page (sección experiencia)
- Badge visible en /cv (sección experiencia), idéntico al de formación adicional
- No se muestra badge cuando duration_months es null o 0
- Sin cambios en lógica de negocio ni tipos