### PR TITLE
feat: make Tool.category optional

### DIFF
--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -228,7 +228,7 @@ const cefrLabel: Record<string, string> = {
 
 // Group tools by category
 const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
-  const cat = tool.category ?? "Otros";
+  const cat = tool.category ?? "";
   if (!acc[cat]) acc[cat] = [];
   acc[cat].push(tool);
   return acc;
@@ -472,7 +472,7 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
             <div class="tools-group-list">
               {Object.entries(toolsByCategory).map(([category, categoryTools]) => (
                 <div class="tools-group">
-                  <p class="tools-category-label">{category}</p>
+                  {category && <p class="tools-category-label">{category}</p>}
                   <div class="tools-tag-row">
                     {categoryTools.map((tool) => (
                       <span class="tools-tag">{tool.name}</span>

--- a/src/tests/integration/pages/cv.integration.test.ts
+++ b/src/tests/integration/pages/cv.integration.test.ts
@@ -209,7 +209,7 @@ describe("CV — skills: API vs fallback", () => {
 describe("CV — tools: agrupación por categoría", () => {
   function groupToolsByCategory(tools: Tool[]): Record<string, Tool[]> {
     return tools.reduce<Record<string, Tool[]>>((acc, tool) => {
-      const cat = tool.category ?? "Otros";
+      const cat = tool.category ?? "";
       if (!acc[cat]) acc[cat] = [];
       acc[cat].push(tool);
       return acc;
@@ -228,21 +228,21 @@ describe("CV — tools: agrupación por categoría", () => {
     }
   });
 
-  it("usa 'Otros' como categoría cuando category es null/undefined", () => {
+  it("agrupa bajo clave vacía cuando category es null/undefined", () => {
     const toolsWithNull: Tool[] = [
       {
         id: "t-null",
         created_at: null,
         updated_at: null,
         name: "Sin categoría",
-        category: null as unknown as string,
+        category: null,
         icon_url: null,
         order_index: 99,
       },
     ];
     const grouped = groupToolsByCategory(toolsWithNull);
-    expect(grouped["Otros"]).toBeDefined();
-    expect(grouped["Otros"].length).toBe(1);
+    expect(grouped[""]).toBeDefined();
+    expect(grouped[""].length).toBe(1);
   });
 
   it("devuelve objeto vacío cuando no hay tools", () => {

--- a/src/types/cv.types.ts
+++ b/src/types/cv.types.ts
@@ -70,7 +70,7 @@ export interface Skill extends BaseEntity {
 
 export interface Tool extends BaseEntity {
   name: string;
-  category: string;
+  category: string | null;
   icon_url: string | null;
   order_index: number;
 }


### PR DESCRIPTION
category is now string | null in the Tool type. Tools without a category are grouped under an empty key and rendered without a label.