### PR TITLE
refactor: rename CSS color variable --blue* to --accent-color*

### DIFF
--- a/src/components-islands/ContactForm.tsx
+++ b/src/components-islands/ContactForm.tsx
@@ -164,7 +164,7 @@ const SUBMIT_BTN: React.CSSProperties = {
   gap: "8px",
   padding: "11px 28px",
   borderRadius: "var(--radius-pill)",
-  background: "var(--blue)",
+  background: "var(--accent-color)",
   color: "#ffffff",
   fontSize: "14.5px",
   fontWeight: 700,
@@ -485,14 +485,14 @@ export default function ContactForm() {
           style={isLoading ? SUBMIT_BTN_LOADING : SUBMIT_BTN}
           onMouseEnter={(e) => {
             if (!isLoading) {
-              (e.currentTarget as HTMLButtonElement).style.background = "var(--blue-2)";
+              (e.currentTarget as HTMLButtonElement).style.background = "var(--accent-color-2)";
               (e.currentTarget as HTMLButtonElement).style.boxShadow =
                 "0 6px 20px rgba(30, 107, 247, 0.38)";
             }
           }}
           onMouseLeave={(e) => {
             if (!isLoading) {
-              (e.currentTarget as HTMLButtonElement).style.background = "var(--blue)";
+              (e.currentTarget as HTMLButtonElement).style.background = "var(--accent-color)";
               (e.currentTarget as HTMLButtonElement).style.boxShadow =
                 "0 4px 14px rgba(30, 107, 247, 0.28)";
             }

--- a/src/components-islands/ScrollToTop.tsx
+++ b/src/components-islands/ScrollToTop.tsx
@@ -8,7 +8,7 @@ function injectStyles() {
   style.id = STYLE_ID;
   style.textContent = `
     .scroll-to-top-btn:focus-visible {
-      outline: 2px solid var(--blue);
+      outline: 2px solid var(--accent-color);
       outline-offset: 4px;
     }
   `;
@@ -45,7 +45,7 @@ export default function ScrollToTop() {
         width: "44px",
         height: "44px",
         borderRadius: "50%",
-        background: "var(--blue)",
+        background: "var(--accent-color)",
         color: "#ffffff",
         border: "none",
         cursor: "pointer",
@@ -59,11 +59,11 @@ export default function ScrollToTop() {
         outlineOffset: "2px",
       }}
       onMouseEnter={(e) => {
-        (e.currentTarget as HTMLButtonElement).style.background = "var(--blue-2)";
+        (e.currentTarget as HTMLButtonElement).style.background = "var(--accent-color-2)";
         (e.currentTarget as HTMLButtonElement).style.transform = "translateY(-2px)";
       }}
       onMouseLeave={(e) => {
-        (e.currentTarget as HTMLButtonElement).style.background = "var(--blue)";
+        (e.currentTarget as HTMLButtonElement).style.background = "var(--accent-color)";
         (e.currentTarget as HTMLButtonElement).style.transform = "translateY(0)";
       }}
     >

--- a/src/components/common/Footer.astro
+++ b/src/components/common/Footer.astro
@@ -47,7 +47,7 @@ const year = new Date().getFullYear();
   }
 
   .footer-links a:hover {
-    color: var(--blue);
+    color: var(--accent-color);
   }
 
   .footer-sep {

--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -72,7 +72,7 @@ import Navigation from "@/components/common/Navigation.astro";
   .nav-brand-dot {
     width: 8px;
     height: 8px;
-    background: var(--blue);
+    background: var(--accent-color);
     border-radius: 50%;
     display: inline-block;
   }
@@ -83,7 +83,7 @@ import Navigation from "@/components/common/Navigation.astro";
     gap: 7px;
     padding: 8px 18px;
     border-radius: var(--radius-pill);
-    background: var(--blue-soft);
+    background: var(--accent-color-soft);
     color: #1557d6;
     font-size: 13px;
     font-weight: 600;

--- a/src/components/common/Navigation.astro
+++ b/src/components/common/Navigation.astro
@@ -75,7 +75,7 @@ const links = [
 
   .nav-link:hover {
     background: var(--soft);
-    color: var(--blue);
+    color: var(--accent-color);
   }
 
   .nav-link-icon {

--- a/src/components/home/AboutCard.astro
+++ b/src/components/home/AboutCard.astro
@@ -130,7 +130,7 @@ const displaySkills = skills.slice(0, 12).map((s, i) => ({
   .stat-value {
     font-size: 28px;
     font-weight: 800;
-    color: var(--blue);
+    color: var(--accent-color);
     line-height: 1;
   }
 

--- a/src/components/home/ContactSection.astro
+++ b/src/components/home/ContactSection.astro
@@ -398,7 +398,7 @@ const services = [
   }
 
   .heading-blue {
-    color: var(--blue);
+    color: var(--accent-color);
   }
 
   .services-grid {
@@ -427,8 +427,8 @@ const services = [
     width: 42px;
     height: 42px;
     border-radius: 10px;
-    background: var(--blue-soft);
-    color: var(--blue);
+    background: var(--accent-color-soft);
+    color: var(--accent-color);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -547,7 +547,7 @@ const services = [
   }
 
   .cf-input:focus {
-    border-color: var(--blue);
+    border-color: var(--accent-color);
   }
 
   .cf-textarea {
@@ -600,7 +600,7 @@ const services = [
     gap: 8px;
     padding: 11px 28px;
     border-radius: var(--radius-pill);
-    background: var(--blue);
+    background: var(--accent-color);
     color: #ffffff;
     font-size: 14.5px;
     font-weight: 700;
@@ -616,7 +616,7 @@ const services = [
   }
 
   .cf-submit:hover:not(:disabled) {
-    background: var(--blue-2);
+    background: var(--accent-color-2);
     box-shadow: 0 6px 20px rgba(30, 107, 247, 0.38);
   }
 

--- a/src/components/home/ExperienceSection.astro
+++ b/src/components/home/ExperienceSection.astro
@@ -102,7 +102,7 @@ const sorted = [...experiences].sort((a, b) => {
     display: inline-block;
     width: 4px;
     height: 22px;
-    background: var(--blue);
+    background: var(--accent-color);
     border-radius: 2px;
     flex-shrink: 0;
   }
@@ -139,7 +139,7 @@ const sorted = [...experiences].sort((a, b) => {
     width: 12px;
     height: 12px;
     border-radius: 50%;
-    background: var(--blue);
+    background: var(--accent-color);
     border: 2.5px solid #ffffff;
     box-shadow: 0 0 0 2px rgba(30, 107, 247, 0.25);
   }
@@ -168,7 +168,7 @@ const sorted = [...experiences].sort((a, b) => {
   .xp-role {
     font-size: 17px;
     font-weight: 700;
-    color: var(--blue);
+    color: var(--accent-color);
     margin-bottom: 3px;
     letter-spacing: -0.01em;
   }
@@ -207,7 +207,7 @@ const sorted = [...experiences].sort((a, b) => {
   }
 
   .xp-dates strong {
-    color: var(--blue);
+    color: var(--accent-color);
     font-weight: 600;
   }
 

--- a/src/components/home/Hero.astro
+++ b/src/components/home/Hero.astro
@@ -226,7 +226,7 @@ const { name, headline, email, github, linkedin, xUrl, website } = Astro.props;
   }
 
   .hero-name {
-    color: var(--blue);
+    color: var(--accent-color);
   }
 
   .hero-role {
@@ -243,7 +243,7 @@ const { name, headline, email, github, linkedin, xUrl, website } = Astro.props;
   .hero-dot {
     width: 6px;
     height: 6px;
-    background: var(--blue);
+    background: var(--accent-color);
     border-radius: 50%;
     display: inline-block;
     flex-shrink: 0;
@@ -275,9 +275,9 @@ const { name, headline, email, github, linkedin, xUrl, website } = Astro.props;
   }
 
   .social-btn:hover {
-    border-color: var(--blue);
-    color: var(--blue);
-    background: var(--blue-soft);
+    border-color: var(--accent-color);
+    color: var(--accent-color);
+    background: var(--accent-color-soft);
     box-shadow: 0 2px 12px rgba(30, 107, 247, 0.15);
   }
 </style>

--- a/src/components/home/ProjectsSection.astro
+++ b/src/components/home/ProjectsSection.astro
@@ -157,7 +157,7 @@ const sorted = [...projects].sort((a, b) => a.order_index - b.order_index);
     display: inline-block;
     width: 4px;
     height: 22px;
-    background: var(--blue);
+    background: var(--accent-color);
     border-radius: 2px;
     flex-shrink: 0;
   }
@@ -226,7 +226,7 @@ const sorted = [...projects].sort((a, b) => a.order_index - b.order_index);
   .project-title {
     font-size: 16px;
     font-weight: 700;
-    color: var(--blue);
+    color: var(--accent-color);
     margin-bottom: 10px;
     line-height: 1.35;
     letter-spacing: -0.01em;
@@ -284,20 +284,20 @@ const sorted = [...projects].sort((a, b) => a.order_index - b.order_index);
   }
 
   .project-link:hover {
-    border-color: var(--blue);
-    color: var(--blue);
-    background: var(--blue-soft);
+    border-color: var(--accent-color);
+    color: var(--accent-color);
+    background: var(--accent-color-soft);
   }
 
   .project-link--primary {
-    background: var(--blue);
+    background: var(--accent-color);
     color: #fff;
-    border-color: var(--blue);
+    border-color: var(--accent-color);
   }
 
   .project-link--primary:hover {
-    background: var(--blue-2);
-    border-color: var(--blue-2);
+    background: var(--accent-color-2);
+    border-color: var(--accent-color-2);
     color: #fff;
   }
 
@@ -318,16 +318,16 @@ const sorted = [...projects].sort((a, b) => a.order_index - b.order_index);
     padding: 7px 16px;
     border-radius: var(--radius-pill);
     border: 1px solid var(--line);
-    background: var(--blue-soft);
+    background: var(--accent-color-soft);
     transition:
       background var(--transition),
       border-color var(--transition);
   }
 
   .projects-cta-link:hover {
-    background: var(--blue);
+    background: var(--accent-color);
     color: #fff;
-    border-color: var(--blue);
+    border-color: var(--accent-color);
   }
 
   .empty {

--- a/src/components/home/StudiesSection.astro
+++ b/src/components/home/StudiesSection.astro
@@ -124,7 +124,7 @@ const studies: StudyItem[] = [...educationItems, ...certItems];
     display: inline-block;
     width: 4px;
     height: 22px;
-    background: var(--blue);
+    background: var(--accent-color);
     border-radius: 2px;
     flex-shrink: 0;
   }
@@ -185,7 +185,7 @@ const studies: StudyItem[] = [...educationItems, ...certItems];
   .study-title {
     font-size: 16px;
     font-weight: 700;
-    color: var(--blue);
+    color: var(--accent-color);
     margin-bottom: 5px;
     line-height: 1.3;
     letter-spacing: -0.01em;
@@ -219,7 +219,7 @@ const studies: StudyItem[] = [...educationItems, ...certItems];
     gap: 5px;
     font-size: 12px;
     font-weight: 600;
-    color: var(--blue);
+    color: var(--accent-color);
     text-decoration: none;
     transition: opacity var(--transition);
   }

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -23,9 +23,9 @@ const { title, description } = Astro.props;
   <button
     id="scroll-to-top"
     aria-label="Volver arriba"
-    style="display:none;position:fixed;bottom:28px;right:28px;width:44px;height:44px;border-radius:50%;background:var(--blue);color:#fff;border:none;cursor:pointer;align-items:center;justify-content:center;box-shadow:0 4px 16px rgba(30,107,247,0.35);z-index:200;transition:background 200ms ease,transform 200ms ease;outline:2px solid transparent;outline-offset:2px;"
-    onmouseenter="this.style.background='var(--blue-2)';this.style.transform='translateY(-2px)'"
-    onmouseleave="this.style.background='var(--blue)';this.style.transform='translateY(0)'"
+    style="display:none;position:fixed;bottom:28px;right:28px;width:44px;height:44px;border-radius:50%;background:var(--accent-color);color:#fff;border:none;cursor:pointer;align-items:center;justify-content:center;box-shadow:0 4px 16px rgba(30,107,247,0.35);z-index:200;transition:background 200ms ease,transform 200ms ease;outline:2px solid transparent;outline-offset:2px;"
+    onmouseenter="this.style.background='var(--accent-color-2)';this.style.transform='translateY(-2px)'"
+    onmouseleave="this.style.background='var(--accent-color)';this.style.transform='translateY(0)'"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -55,7 +55,7 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
     line-height: 1;
     margin-bottom: 16px;
     letter-spacing: -4px;
-    color: var(--blue-soft);
+    color: var(--accent-color-soft);
     -webkit-text-stroke: 1.5px rgba(30, 107, 247, 0.4);
   }
 
@@ -88,7 +88,7 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
     gap: 8px;
     padding: 12px 24px;
     border-radius: var(--radius-pill);
-    background: var(--blue);
+    background: var(--accent-color);
     color: #ffffff;
     font-size: 14px;
     font-weight: 700;
@@ -98,7 +98,7 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
   }
 
   .btn-home:hover {
-    background: var(--blue-2);
+    background: var(--accent-color-2);
   }
 
   .btn-cv {
@@ -118,7 +118,7 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
   }
 
   .btn-cv:hover {
-    border-color: var(--blue);
-    color: var(--blue);
+    border-color: var(--accent-color);
+    color: var(--accent-color);
   }
 </style>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -207,7 +207,7 @@ const projects: MockProject[] = [
   .page-overline {
     font-size: 11px;
     font-weight: 700;
-    color: var(--blue);
+    color: var(--accent-color);
     text-transform: uppercase;
     letter-spacing: 0.1em;
     margin-bottom: 8px;
@@ -306,7 +306,7 @@ const projects: MockProject[] = [
   .project-title {
     font-size: 16px;
     font-weight: 700;
-    color: var(--blue);
+    color: var(--accent-color);
     margin-bottom: 10px;
     line-height: 1.35;
     letter-spacing: -0.01em;
@@ -366,20 +366,20 @@ const projects: MockProject[] = [
   }
 
   .project-link:hover {
-    border-color: var(--blue);
-    color: var(--blue);
-    background: var(--blue-soft);
+    border-color: var(--accent-color);
+    color: var(--accent-color);
+    background: var(--accent-color-soft);
   }
 
   .project-link--primary {
-    background: var(--blue);
+    background: var(--accent-color);
     color: #fff;
-    border-color: var(--blue);
+    border-color: var(--accent-color);
   }
 
   .project-link--primary:hover {
-    background: var(--blue-2);
-    border-color: var(--blue-2);
+    background: var(--accent-color-2);
+    border-color: var(--accent-color-2);
     color: #fff;
   }
 

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -7,9 +7,9 @@
   --line: #e8ecf4;
   --card: #ffffff;
   --soft: #f5f8fd;
-  --blue: #1e6bf7;
-  --blue-2: #3c83ff;
-  --blue-soft: #eaf1ff;
+  --accent-color: #1e6bf7;
+  --accent-color-2: #3c83ff;
+  --accent-color-soft: #eaf1ff;
   --dot: #d9e0ee;
   --radius: 16px;
   --radius-lg: 24px;


### PR DESCRIPTION
Replace --blue, --blue-2, and --blue-soft with --accent-color, --accent-color-2, and --accent-color-soft across 15 files for more semantic and theme-agnostic naming.