### PR TITLE
Fix/tech badge pills

### DIFF
--- a/src/components/home/ProjectsSection.astro
+++ b/src/components/home/ProjectsSection.astro
@@ -1,6 +1,7 @@
----
+﻿---
 import { ROUTES } from "@/config/constants";
 import type { Project } from "@/types/cv.types";
+import TechBadge from "@/components/ui/TechBadge.astro";
 
 interface Props {
   projects: Project[];
@@ -44,10 +45,14 @@ const sorted = [...projects].sort((a, b) => a.order_index - b.order_index);
                 <p class="project-desc">{p.description}</p>
 
                 {p.technologies.length > 0 && (
-                  <div class="project-tags">
-                    {p.technologies.map((tech) => (
-                      <span class="project-tag">{tech}</span>
-                    ))}
+                  <div class="project-tags" role="list" aria-label="Stack tecnológico">
+                    {p.technologies
+                      .flatMap((tech) =>
+                        tech.includes(",") ? tech.split(",").map((t) => t.trim()) : [tech]
+                      )
+                      .map((tech) => (
+                        <TechBadge tech={tech} />
+                      ))}
                   </div>
                 )}
 
@@ -245,17 +250,6 @@ const sorted = [...projects].sort((a, b) => a.order_index - b.order_index);
     flex-wrap: wrap;
     gap: 6px;
     margin-bottom: 16px;
-  }
-
-  .project-tag {
-    display: inline-block;
-    padding: 3px 10px;
-    border-radius: var(--radius-pill);
-    background: var(--soft);
-    color: var(--ink-2);
-    font-size: 12px;
-    font-weight: 600;
-    border: 1px solid var(--line);
   }
 
   .project-links {

--- a/src/components/ui/Badge.astro
+++ b/src/components/ui/Badge.astro
@@ -3,11 +3,13 @@ interface Props {
   label: string;
   variant?: "default" | "outline" | "c1" | "c2" | "c3" | "c4" | "c5" | "c6";
   class?: string;
+  style?: string;
 }
-const { label, variant = "default", class: className } = Astro.props;
+const { label, variant = "default", class: className, style } = Astro.props;
 ---
 
 <span
+  style={style}
   class:list={[
     "inline-flex items-center gap-[var(--space-inline-xs)]",
     "rounded-[var(--radius-badge)]",

--- a/src/components/ui/TechBadge.astro
+++ b/src/components/ui/TechBadge.astro
@@ -1,0 +1,39 @@
+---
+import Badge from "./Badge.astro";
+
+type BadgeVariant = "default" | "outline" | "c1" | "c2" | "c3" | "c4" | "c5" | "c6";
+
+interface Props {
+  tech: string;
+  class?: string;
+}
+
+const TECH_COLORS: Record<string, BadgeVariant> = {
+  python: "c2",
+  fastapi: "c2",
+  typescript: "c1",
+  react: "c1",
+  astro: "c5",
+  tailwind: "c6",
+  tailwindcss: "c6",
+  "tailwind css": "c6",
+  mongodb: "c2",
+  docker: "c6",
+  pytest: "c3",
+  javascript: "c1",
+  html: "c3",
+  css: "c1",
+  vite: "c5",
+  vitest: "c5",
+  git: "c3",
+  github: "c3",
+  "git + github": "c3",
+  "git+github": "c3",
+};
+
+const { tech, class: className } = Astro.props;
+
+const variant: BadgeVariant = TECH_COLORS[tech.toLowerCase()] ?? "c1";
+---
+
+<Badge label={tech} variant={variant} class={className} />

--- a/src/components/ui/TechBadge.astro
+++ b/src/components/ui/TechBadge.astro
@@ -6,6 +6,7 @@ type BadgeVariant = "default" | "outline" | "c1" | "c2" | "c3" | "c4" | "c5" | "
 interface Props {
   tech: string;
   class?: string;
+  size?: "sm" | "md";
 }
 
 const TECH_COLORS: Record<string, BadgeVariant> = {
@@ -31,9 +32,10 @@ const TECH_COLORS: Record<string, BadgeVariant> = {
   "git+github": "c3",
 };
 
-const { tech, class: className } = Astro.props;
+const { tech, class: className, size = "md" } = Astro.props;
 
 const variant: BadgeVariant = TECH_COLORS[tech.toLowerCase()] ?? "c1";
+const sizeStyle = size === "sm" ? "font-size: 10px; padding: 3px 8px;" : undefined;
 ---
 
-<Badge label={tech} variant={variant} class={className} />
+<Badge label={tech} variant={variant} class={className} style={sizeStyle} />

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -693,7 +693,7 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
                               : [tech]
                           )
                           .map((tech) => (
-                            <TechBadge tech={tech} />
+                            <TechBadge tech={tech} size="sm" />
                           ))}
                       </div>
                     )}

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -31,6 +31,7 @@ import type {
 import { formatDate, formatDateRange } from "@/utils/formatters";
 import { formatDuration } from "@/utils/date.utils";
 import { PAGE_SEO } from "@/config/seo";
+import TechBadge from "@/components/ui/TechBadge.astro";
 
 const cvResult = await fetchPageData(() => getCVComplete());
 
@@ -682,9 +683,18 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
                     {project.description && <p class="xp-desc">{project.description}</p>}
                     {project.technologies.length > 0 && (
                       <div class="project-tech-list">
-                        {project.technologies.map((tech) => (
-                          <span class="project-tech-badge">{tech}</span>
-                        ))}
+                        {project.technologies
+                          .flatMap((tech) =>
+                            tech.includes(",")
+                              ? tech
+                                  .split(",")
+                                  .map((t) => t.trim())
+                                  .filter(Boolean)
+                              : [tech]
+                          )
+                          .map((tech) => (
+                            <TechBadge tech={tech} />
+                          ))}
                       </div>
                     )}
                   </div>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -20,6 +20,7 @@ export const prerender = true;
 
 import MainLayout from "@/layouts/MainLayout.astro";
 import { PAGE_SEO } from "@/config/seo";
+import TechBadge from "@/components/ui/TechBadge.astro";
 
 interface MockProject {
   subtitle: string;
@@ -113,9 +114,7 @@ const projects: MockProject[] = [
                 {/* Stack técnico */}
                 <div class="project-tags" role="list" aria-label="Stack tecnológico">
                   {p.tags.map((tag) => (
-                    <span class="project-tag" role="listitem">
-                      {tag}
-                    </span>
+                    <TechBadge tech={tag} />
                   ))}
                 </div>
 
@@ -326,17 +325,6 @@ const projects: MockProject[] = [
     flex-wrap: wrap;
     gap: 6px;
     margin-bottom: 16px;
-  }
-
-  .project-tag {
-    display: inline-block;
-    padding: 3px 10px;
-    border-radius: var(--radius-pill);
-    background: var(--soft);
-    color: var(--ink-2);
-    font-size: 12px;
-    font-weight: 600;
-    border: 1px solid var(--line);
   }
 
   /* CTAs */


### PR DESCRIPTION
## Summary

  - Add `size?: "sm" | "md"` prop to `TechBadge.astro` and forward a `style` inline override to `Badge.astro` to bypass
  its scoped CSS specificity.
  - `cv.astro` uses `size="sm"` (font-size 10px, padding 3px 8px) in the projects section to keep the CV layout más
  compacto.
  - Home (`ProjectsSection.astro`) and `/projects` page are unaffected — omitting `size` defaults to `"md"` with no
  style attribute applied.

  ## Test plan

  - [x] Verificar en `/cv` que los badges de tecnología en proyectos se ven más pequeños que los de la home
  - [x] Verificar en `/` (home) que los badges de proyectos mantienen su tamaño original
  - [x] Verificar en `/projects` que los badges no cambiaron
  - [x] Confirmar que badges con tecnologías no mapeadas (fallback `c1`) siguen visibles con el tamaño correcto en cada
  página