### PR TITLE
feat(header): add responsive breakpoints and hamburger menu

### DIFF
--- a/src/components-islands/HamburgerMenu.tsx
+++ b/src/components-islands/HamburgerMenu.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useRef, useState } from "react";
+import type { NavLink } from "@/config/navigation";
+
+const STYLE_ID = "hamburger-menu-styles";
+
+function injectStyles() {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = `
+    .hamburger-wrapper {
+      position: relative;
+    }
+
+    .hamburger-btn {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 36px;
+      height: 36px;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      border-radius: var(--radius-pill);
+      color: var(--ink-2);
+      transition: background var(--transition), color var(--transition);
+    }
+
+    .hamburger-btn:hover {
+      background: var(--soft);
+      color: var(--accent-color);
+    }
+
+    .hamburger-dropdown {
+      position: absolute;
+      top: calc(100% + 8px);      
+      min-width: 210px;
+      background: rgba(255, 255, 255, 0.97);
+      backdrop-filter: blur(12px);
+      -webkit-backdrop-filter: blur(12px);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      box-shadow: var(--shadow-card);
+      z-index: 210;
+      padding: 6px;
+      list-style: none;
+    }
+
+    .hamburger-dropdown ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    .hamburger-link {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 9px 12px;
+      border-radius: 8px;
+      font-size: 13.5px;
+      font-weight: 500;
+      color: var(--ink-2);
+      text-decoration: none;
+      transition: background var(--transition), color var(--transition);
+    }
+
+    .hamburger-link:hover {
+      background: var(--soft);
+      color: var(--accent-color);
+    }
+
+    .hamburger-link span:first-child {
+      display: flex;
+      align-items: center;
+      color: var(--ink-3);
+    }
+
+    .hamburger-cv-link {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-top: 4px;
+      padding: 9px 12px;
+      border-top: 1px solid var(--line);
+      border-radius: 8px;
+      font-size: 12.5px;
+      font-weight: 600;
+      color: #1557d6;
+      text-decoration: none;
+      background: var(--accent-color-soft);
+      transition: background var(--transition);
+    }
+
+    .hamburger-cv-link:hover {
+      background: #d4e5ff;
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+interface Props {
+  links: NavLink[];
+  cvHref: string;
+}
+
+export default function HamburgerMenu({ links, cvHref }: Props) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    injectStyles();
+  }, []);
+
+  useEffect(() => {
+    function handleMouseDown(event: MouseEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, []);
+
+  function toggle() {
+    setOpen((prev) => !prev);
+  }
+
+  return (
+    <div ref={wrapperRef} className="hamburger-wrapper" style={{ position: "relative" }}>
+      <button
+        className="hamburger-btn"
+        onClick={toggle}
+        aria-expanded={open}
+        aria-label={open ? "Cerrar menú" : "Abrir menú"}
+      >
+        {open ? (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        ) : (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="3" y1="12" x2="21" y2="12" />
+            <line x1="3" y1="6" x2="21" y2="6" />
+            <line x1="3" y1="18" x2="21" y2="18" />
+          </svg>
+        )}
+      </button>
+
+      {open && (
+        <div
+          className="hamburger-dropdown animate-fade-in"
+          role="navigation"
+          aria-label="Menú móvil"
+        >
+          <ul>
+            {links.map(({ label, href, icon }) => (
+              <li key={href}>
+                <a href={href} onClick={() => setOpen(false)} className="hamburger-link">
+                  <span dangerouslySetInnerHTML={{ __html: icon }} aria-hidden="true" />
+                  <span>{label}</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+          <a href={cvHref} onClick={() => setOpen(false)} className="hamburger-cv-link">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="13"
+              height="13"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+              <polyline points="14 2 14 8 20 8"></polyline>
+              <line x1="16" y1="13" x2="8" y2="13"></line>
+              <line x1="16" y1="17" x2="8" y2="17"></line>
+              <polyline points="10 9 9 9 8 9"></polyline>
+            </svg>
+            Ver / Descargar CV
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/common/Header.astro
+++ b/src/components/common/Header.astro
@@ -1,7 +1,9 @@
 ---
 import { SITE } from "@/config/site";
 import { ROUTES } from "@/config/constants";
+import { NAV_LINKS } from "@/config/navigation";
 import Navigation from "@/components/common/Navigation.astro";
+import HamburgerMenu from "@/components-islands/HamburgerMenu";
 ---
 
 <header class="nav-header">
@@ -12,6 +14,7 @@ import Navigation from "@/components/common/Navigation.astro";
     </a>
 
     <Navigation />
+    <HamburgerMenu client:load links={NAV_LINKS} cvHref={ROUTES.cv} />
 
     <!-- Badge CV -->
     <a href={ROUTES.cv} target="_blank" class="hero-badge">
@@ -97,5 +100,39 @@ import Navigation from "@/components/common/Navigation.astro";
   .hero-badge:hover {
     background: #d4e5ff;
     box-shadow: 0 2px 12px rgba(30, 107, 247, 0.15);
+  }
+
+  /* Hamburger oculto por encima de 520px */
+  :global(.hamburger-wrapper) {
+    display: none;
+  }
+
+  /* ── 885px ── */
+  @media (max-width: 885px) {
+    .nav-brand {
+      display: none;
+    }
+
+    .hero-badge {
+      padding: 6px 14px;
+      font-size: 12px;
+    }
+  }
+
+  /* ── 520px ── */
+  @media (max-width: 520px) {
+    :global(.main-nav) {
+      display: none;
+    }
+
+    :global(.hamburger-wrapper) {
+      display: block;
+    }
+
+    .hero-badge {
+      padding: 5px 11px;
+      font-size: 11.5px;
+      gap: 5px;
+    }
   }
 </style>

--- a/src/components/common/Navigation.astro
+++ b/src/components/common/Navigation.astro
@@ -1,39 +1,9 @@
 ---
-const links = [
-  {
-    label: "Inicio",
-    href: "/#inicio",
-    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>`,
-  },
-  {
-    label: "Experiencia",
-    href: "/#experiencia",
-    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="14" x="2" y="7" rx="2" ry="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/></svg>`,
-  },
-  {
-    label: "Estudios",
-    href: "/#estudios",
-    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10v6M2 10l10-5 10 5-10 5z"/><path d="M6 12v5c3 3 9 3 12 0v-5"/></svg>`,
-  },
-  {
-    label: "Proyectos",
-    href: "/#proyectos",
-    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>`,
-  },
-  {
-    label: "Contacto",
-    href: "/#contacto",
-    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>`,
-  },
-  // {
-  //   label: "CV",
-  //   href: ROUTES.cv,
-  //   icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>`,
-  // },
-];
+import { NAV_LINKS } from "@/config/navigation";
+const links = NAV_LINKS;
 ---
 
-<nav aria-label="Navegación principal">
+<nav class="main-nav" aria-label="Navegación principal">
   <ul class="nav-links">
     {
       links.map(({ label, href, icon }) => (
@@ -84,7 +54,7 @@ const links = [
     color: var(--ink-3);
   }
 
-  @media (max-width: 640px) {
+  @media (max-width: 765px) {
     .nav-links {
       gap: 2px;
     }

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -1,0 +1,33 @@
+export interface NavLink {
+  label: string;
+  href: string;
+  icon: string;
+}
+
+export const NAV_LINKS: NavLink[] = [
+  {
+    label: "Inicio",
+    href: "/#inicio",
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>`,
+  },
+  {
+    label: "Experiencia",
+    href: "/#experiencia",
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="14" x="2" y="7" rx="2" ry="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/></svg>`,
+  },
+  {
+    label: "Estudios",
+    href: "/#estudios",
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10v6M2 10l10-5 10 5-10 5z"/><path d="M6 12v5c3 3 9 3 12 0v-5"/></svg>`,
+  },
+  {
+    label: "Proyectos",
+    href: "/#proyectos",
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>`,
+  },
+  {
+    label: "Contacto",
+    href: "/#contacto",
+    icon: `<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>`,
+  },
+];


### PR DESCRIPTION
- Extract nav links to navigation.ts as single source of truth
- Hide nav-brand at ≤885px, reduce hero-badge size subtly
- At ≤520px replace nav with HamburgerMenu React island (dropdown with all links + CV link)