### PR TITLE
feat(cv): align CV design tokens with home design system

### DIFF
--- a/src/components-islands/DownloadButton.tsx
+++ b/src/components-islands/DownloadButton.tsx
@@ -63,16 +63,16 @@ const BASE_STYLE: React.CSSProperties = {
   alignItems: "center",
   gap: "6px",
   padding: "7px 16px",
-  borderRadius: "999px",
+  borderRadius: "var(--radius-pill)",
   fontSize: "12px",
   fontWeight: 700,
   letterSpacing: "0.06em",
   color: "#ffffff",
-  background: "#00507d",
+  background: "var(--color-blue)",
   border: "none",
   cursor: "pointer",
   textTransform: "uppercase",
-  transition: "background 200ms ease",
+  transition: "background var(--transition)",
   userSelect: "none",
 };
 
@@ -187,12 +187,12 @@ export default function DownloadButton({
         style={loading ? LOADING_STYLE : BASE_STYLE}
         onMouseEnter={(e) => {
           if (!loading) {
-            (e.currentTarget as HTMLButtonElement).style.background = "#2a78a6";
+            (e.currentTarget as HTMLButtonElement).style.background = "var(--color-blue-2)";
           }
         }}
         onMouseLeave={(e) => {
           if (!loading) {
-            (e.currentTarget as HTMLButtonElement).style.background = "#00507d";
+            (e.currentTarget as HTMLButtonElement).style.background = "var(--color-blue)";
           }
         }}
       >

--- a/src/components/cv/SkillList.astro
+++ b/src/components/cv/SkillList.astro
@@ -1,17 +1,27 @@
 ---
-import type { Skill } from "@/types/cv.types";
+import type { Skill, SkillLevel } from "@/types/cv.types";
 import SectionTitle from "@/components/ui/SectionTitle.astro";
 
 interface Props {
   skills: Skill[];
 }
 const { skills } = Astro.props;
+
+function chipClass(level: SkillLevel | null): string {
+  const map: Partial<Record<SkillLevel, string>> = {
+    expert: "chip-c1",
+    advanced: "chip-c2",
+    intermediate: "chip-c5",
+    basic: "chip-c6",
+  };
+  return map[level ?? "none"] ?? "chip-neutral";
+}
 ---
 
 <section>
   <SectionTitle title="Habilidades" />
   <div class="tag-row">
-    {skills.map((skill) => <span class="skill-tag">{skill.name}</span>)}
+    {skills.map((skill) => <span class={`skill-tag ${chipClass(skill.level)}`}>{skill.name}</span>)}
   </div>
 </section>
 
@@ -24,12 +34,35 @@ const { skills } = Astro.props;
 
   .skill-tag {
     display: inline-block;
-    padding: 2px 8px;
-    border-radius: 999px;
-    background: #f0f4fa;
-    color: #1a2747;
+    padding: 2px 9px;
+    border-radius: var(--radius-pill);
     font-size: 11px;
     font-weight: 500;
-    border: 1px solid #dce4f0;
+  }
+
+  .chip-c1 {
+    background: var(--color-chip-c1-bg);
+    color: var(--color-chip-c1-text);
+  }
+
+  .chip-c2 {
+    background: var(--color-chip-c2-bg);
+    color: var(--color-chip-c2-text);
+  }
+
+  .chip-c5 {
+    background: var(--color-chip-c5-bg);
+    color: var(--color-chip-c5-text);
+  }
+
+  .chip-c6 {
+    background: var(--color-chip-c6-bg);
+    color: var(--color-chip-c6-text);
+  }
+
+  .chip-neutral {
+    background: var(--color-soft);
+    color: var(--color-ink-2);
+    border: 1px solid var(--color-line);
   }
 </style>

--- a/src/layouts/CVLayout.astro
+++ b/src/layouts/CVLayout.astro
@@ -102,10 +102,9 @@ const { title, description, noindex = false } = Astro.props;
   <!-- Scroll-to-top (nativo, sin React) -->
   <button
     id="scroll-to-top-cv"
+    class="scroll-to-top-btn"
     aria-label="Volver arriba"
-    style="display:none;position:fixed;bottom:28px;right:28px;width:44px;height:44px;border-radius:50%;background:#00507d;color:#fff;border:none;cursor:pointer;align-items:center;justify-content:center;box-shadow:0 4px 16px rgba(0,80,125,0.35);z-index:200;transition:background 200ms ease,transform 200ms ease;"
-    onmouseenter="this.style.background='#2a78a6';this.style.transform='translateY(-2px)'"
-    onmouseleave="this.style.background='#00507d';this.style.transform='translateY(0)'"
+    style="display:none"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -144,15 +143,15 @@ const { title, description, noindex = false } = Astro.props;
   /* Reset body background for CV page */
   :global(body) {
     background-image: none !important;
-    background-color: var(--cv-bg, #f4f6fa) !important;
+    background-color: var(--color-cv-bg) !important;
   }
 
   .cv-bar {
     position: sticky;
     top: 0;
     z-index: 100;
-    background: #ffffff;
-    border-bottom: 1px solid #e8ecf4;
+    background: var(--color-card);
+    border-bottom: 1px solid var(--color-line);
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
   }
 
@@ -173,14 +172,14 @@ const { title, description, noindex = false } = Astro.props;
     gap: 8px;
     font-size: 14px;
     font-weight: 700;
-    color: #1a2747;
+    color: var(--color-ink);
     letter-spacing: -0.01em;
   }
 
   .cv-bar-dot {
     width: 7px;
     height: 7px;
-    background: #00507d;
+    background: var(--color-blue);
     border-radius: 50%;
     display: inline-block;
     flex-shrink: 0;
@@ -197,21 +196,21 @@ const { title, description, noindex = false } = Astro.props;
     align-items: center;
     gap: 5px;
     padding: 6px 14px;
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     font-size: 13px;
     font-weight: 500;
-    color: #4a5a7a;
+    color: var(--color-ink-2);
     text-decoration: none;
-    border: 1px solid #e8ecf4;
-    background: #f5f8fd;
+    border: 1px solid var(--color-line);
+    background: var(--color-soft);
     transition:
-      border-color 200ms ease,
-      color 200ms ease;
+      border-color var(--transition),
+      color var(--transition);
   }
 
   .cv-back-btn:hover {
-    border-color: #00507d;
-    color: #00507d;
+    border-color: var(--color-blue);
+    color: var(--color-blue);
   }
 
   .cv-download-btn {
@@ -219,35 +218,61 @@ const { title, description, noindex = false } = Astro.props;
     align-items: center;
     gap: 6px;
     padding: 7px 16px;
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     font-size: 12px;
     font-weight: 700;
     letter-spacing: 0.06em;
     color: #ffffff;
-    background: #00507d;
+    background: var(--color-blue);
     border: none;
     cursor: pointer;
     text-transform: uppercase;
-    transition: background 200ms ease;
+    transition: background var(--transition);
   }
 
   .cv-download-btn:hover {
-    background: #2a78a6;
+    background: var(--color-blue-2);
   }
 
   .cv-bg {
     min-height: calc(100vh - 52px);
-    background: #f4f6fa;
+    background: var(--color-cv-bg);
     padding: 40px 24px 60px;
   }
 
   .cv-paper {
     max-width: 860px;
     margin: 0 auto;
-    background: #ffffff;
-    border-radius: 8px;
-    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.1);
+    background: var(--color-cv-paper);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-card-hover);
     overflow: hidden;
+  }
+
+  .scroll-to-top-btn {
+    position: fixed;
+    bottom: 28px;
+    right: 28px;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: var(--color-blue);
+    color: #fff;
+    border: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 16px rgba(30, 107, 247, 0.3);
+    z-index: 200;
+    transition:
+      background var(--transition),
+      transform var(--transition);
+  }
+
+  .scroll-to-top-btn:hover {
+    background: var(--color-blue-2);
+    transform: translateY(-2px);
   }
 
   @media print {

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -742,9 +742,9 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
 
   /* SIDEBAR */
   .cv-sidebar {
-    border-right: 1px solid #e8ecf4;
+    border-right: 1px solid var(--color-line);
     padding: 32px 22px;
-    background: #fafbfd;
+    background: var(--color-soft);
   }
 
   .sidebar-section {
@@ -760,9 +760,9 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
     font-weight: 800;
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    color: #1a2747;
+    color: var(--color-ink);
     padding-bottom: 8px;
-    border-bottom: 2px solid #1a2747;
+    border-bottom: 2px solid var(--color-ink);
     margin-bottom: 12px;
   }
 
@@ -780,17 +780,17 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
     align-items: center;
     gap: 8px;
     font-size: 12.5px;
-    color: #4a5a7a;
+    color: var(--color-ink-2);
     line-height: 1.4;
   }
 
   .contact-list li svg {
     flex-shrink: 0;
-    color: #8592b0;
+    color: var(--cv-ink-muted);
   }
 
   .contact-list a {
-    color: #00507d;
+    color: var(--color-blue);
     text-decoration: none;
     word-break: break-all;
     font-size: 12px;
@@ -808,9 +808,9 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
 
   .cert-card {
     padding: 10px 12px;
-    border: 1px solid #e8ecf4;
-    border-radius: 8px;
-    background: #ffffff;
+    border: 1px solid var(--color-line);
+    border-radius: var(--radius-sm);
+    background: var(--color-card);
     display: block;
     text-decoration: none;
   }
@@ -819,26 +819,26 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
     cursor: pointer;
     color: inherit;
     transition:
-      border-color 0.15s ease,
-      box-shadow 0.15s ease;
+      border-color var(--transition),
+      box-shadow var(--transition);
   }
 
   .cert-card--link:hover {
-    border-color: #00507d;
-    box-shadow: 0 2px 8px rgba(0, 80, 125, 0.1);
+    border-color: var(--color-blue);
+    box-shadow: var(--shadow-card);
   }
 
   .cert-title {
     font-size: 12px;
     font-weight: 600;
-    color: #1a2747;
+    color: var(--color-ink);
     margin-bottom: 2px;
     line-height: 1.35;
   }
 
   .cert-issuer {
     font-size: 11px;
-    color: #8592b0;
+    color: var(--cv-ink-muted);
     margin-bottom: 0;
   }
 
@@ -852,7 +852,7 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
 
   .cert-date {
     font-size: 9px;
-    color: #8592b0;
+    color: var(--cv-ink-muted);
     margin: 0;
   }
 
@@ -862,14 +862,14 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
     gap: 3px;
     font-size: 11px;
     font-weight: 600;
-    color: #00507d;
+    color: var(--color-blue);
     margin-left: auto;
     flex-shrink: 0;
   }
 
   .sidebar-skills {
     font-size: 12.5px;
-    color: #4a5a7a;
+    color: var(--color-ink-2);
     line-height: 1.65;
   }
 
@@ -884,7 +884,7 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
 
   .project-list a {
     font-size: 12.5px;
-    color: #00507d;
+    color: var(--color-blue);
     text-decoration: none;
     display: flex;
     align-items: center;
@@ -894,7 +894,7 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
   .project-list a::before {
     content: "→";
     font-size: 11px;
-    color: #8592b0;
+    color: var(--cv-ink-muted);
   }
 
   .project-list a:hover {
@@ -909,13 +909,13 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
   .cv-main-header {
     margin-bottom: 32px;
     padding-bottom: 20px;
-    border-bottom: 1px solid #e8ecf4;
+    border-bottom: 1px solid var(--color-line);
   }
 
   .cv-name {
     font-size: 22px;
     font-weight: 800;
-    color: #1a2747;
+    color: var(--color-ink);
     letter-spacing: 0.04em;
     line-height: 1.1;
     margin-bottom: 4px;
@@ -924,7 +924,7 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
   .cv-headline {
     font-size: 11px;
     font-weight: 600;
-    color: #00507d;
+    color: var(--color-blue);
     letter-spacing: 0.1em;
     text-transform: uppercase;
     margin-bottom: 14px;
@@ -932,7 +932,7 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
 
   .cv-intro {
     font-size: 13.5px;
-    color: #4a5a7a;
+    color: var(--color-ink-2);
     line-height: 1.7;
     max-width: 540px;
   }
@@ -951,9 +951,9 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
     font-weight: 800;
     text-transform: uppercase;
     letter-spacing: 0.09em;
-    color: #1a2747;
+    color: var(--color-ink);
     padding-bottom: 8px;
-    border-bottom: 1.5px solid #e8ecf4;
+    border-bottom: 1.5px solid var(--color-line);
     margin-bottom: 18px;
   }
 
@@ -970,7 +970,7 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
     top: 6px;
     bottom: 6px;
     width: 1.5px;
-    background: #e8ecf4;
+    background: var(--color-line);
   }
 
   .xp-item {
@@ -989,9 +989,9 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
     width: 9px;
     height: 9px;
     border-radius: 50%;
-    background: #00507d;
+    background: var(--color-blue);
     border: 2px solid #ffffff;
-    box-shadow: 0 0 0 1.5px rgba(0, 80, 125, 0.3);
+    box-shadow: 0 0 0 1.5px rgba(30, 107, 247, 0.25);
   }
 
   .xp-content {
@@ -1001,14 +1001,14 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
   .xp-role {
     font-size: 14px;
     font-weight: 700;
-    color: #1a2747;
+    color: var(--color-ink);
     margin-bottom: 6px;
     line-height: 1.3;
   }
 
   .xp-company {
     font-weight: 400;
-    color: #4a5a7a;
+    color: var(--color-ink-2);
     font-style: normal;
   }
 
@@ -1024,9 +1024,9 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
   .xp-dates-pill {
     display: inline-block;
     padding: 2px 10px;
-    border-radius: 999px;
-    background: #e0eef6;
-    color: #00507d;
+    border-radius: var(--radius-pill);
+    background: var(--color-blue-soft);
+    color: var(--color-blue);
     font-size: 11px;
     font-weight: 600;
   }
@@ -1034,7 +1034,7 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
   .xp-location-pill {
     display: inline-block;
     padding: 2px 10px;
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     background: #fdebee;
     color: #c23a52;
     font-size: 11px;
@@ -1043,26 +1043,25 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
 
   .xp-company-inline {
     font-size: 12.5px;
-    color: #4a5a7a;
+    color: var(--color-ink-2);
     font-weight: 500;
   }
 
   .xp-desc {
     font-size: 13px;
-    color: #4a5a7a;
+    color: var(--color-ink-2);
     line-height: 1.65;
   }
 
-  /* Skills sidebar overrides — SkillList uses Tailwind classes which work fine,
-     but section title from SectionTitle.astro needs to match sidebar heading style */
+  /* Skills sidebar overrides — section title from SectionTitle.astro matches sidebar heading style */
   .sidebar-skill-list :global(h2) {
     font-size: 10px;
     font-weight: 800;
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    color: #1a2747;
+    color: var(--color-ink);
     padding-bottom: 8px;
-    border-bottom: 2px solid #1a2747;
+    border-bottom: 2px solid var(--color-ink);
     margin-bottom: 12px;
     border-top: none;
     padding-top: 0;
@@ -1074,7 +1073,7 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
 
   /* Project title link */
   .project-title-link {
-    color: #00507d;
+    color: var(--color-blue);
     text-decoration: none;
   }
 
@@ -1087,9 +1086,9 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
     display: inline-block;
     margin-left: 8px;
     padding: 1px 8px;
-    border-radius: 999px;
-    background: #e6f4ea;
-    color: #276b3a;
+    border-radius: var(--radius-pill);
+    background: var(--color-chip-c2-bg);
+    color: var(--color-chip-c2-text);
     font-size: 10.5px;
     font-weight: 600;
     vertical-align: middle;
@@ -1107,12 +1106,12 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
   .project-tech-badge {
     display: inline-block;
     padding: 2px 9px;
-    border-radius: 999px;
-    background: #f0f4fa;
-    color: #1a2747;
+    border-radius: var(--radius-pill);
+    background: var(--color-soft);
+    color: var(--color-ink);
     font-size: 11px;
     font-weight: 500;
-    border: 1px solid #dce4f0;
+    border: 1px solid var(--color-line);
   }
 
   /* Tools sidebar */
@@ -1133,7 +1132,7 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: #8592b0;
+    color: var(--cv-ink-muted);
     margin-bottom: 2px;
   }
 
@@ -1146,12 +1145,12 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
   .tools-tag {
     display: inline-block;
     padding: 2px 8px;
-    border-radius: 999px;
-    background: #f0f4fa;
-    color: #1a2747;
+    border-radius: var(--radius-pill);
+    background: var(--color-soft);
+    color: var(--color-ink);
     font-size: 11px;
     font-weight: 500;
-    border: 1px solid #dce4f0;
+    border: 1px solid var(--color-line);
   }
 
   /* Languages sidebar */
@@ -1173,24 +1172,24 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
   .lang-name {
     font-size: 12.5px;
     font-weight: 600;
-    color: #1a2747;
+    color: var(--color-ink);
   }
 
   .lang-level {
     font-size: 11px;
-    color: #8592b0;
+    color: var(--cv-ink-muted);
   }
 
   /* Additional training duration pill */
   .training-duration-pill {
     display: inline-block;
     padding: 2px 10px;
-    border-radius: 999px;
-    background: #f0f4fa;
-    color: #4a5a7a;
+    border-radius: var(--radius-pill);
+    background: var(--color-soft);
+    color: var(--color-ink-2);
     font-size: 11px;
     font-weight: 500;
-    border: 1px solid #dce4f0;
+    border: 1px solid var(--color-line);
   }
 
   /* Print */
@@ -1209,7 +1208,7 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
 
     .cv-sidebar {
       border-right: none;
-      border-bottom: 1px solid #e8ecf4;
+      border-bottom: 1px solid var(--color-line);
     }
   }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -24,9 +24,6 @@
   /* --- Colores CV --- */
   --color-cv-bg: #f4f6fa;
   --color-cv-paper: #ffffff;
-  --color-cv-brand: #00507d;
-  --color-cv-brand-2: #2a78a6;
-  --color-cv-brand-soft: #e0eef6;
 
   /* --- Skill chip colors --- */
   --color-chip-c1-bg: #e9efff;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -4,6 +4,7 @@
   --ink: #1a2747;
   --ink-2: #4a5a7a;
   --ink-3: #4c5872;
+  --cv-ink-muted: #8592b0;
   --line: #e8ecf4;
   --card: #ffffff;
   --soft: #f5f8fd;


### PR DESCRIPTION
Replace hard-coded #00507d navy accent with the shared --color-blue token across cv.astro, CVLayout.astro, SkillList.astro and DownloadButton.tsx.
Migrate all remaining hard-coded colors, borders, shadows, radii and transitions in the CV style block to CSS custom properties from variables.css and global.css @theme. Add --cv-ink-muted token for subdued meta text.
Remove obsolete --color-cv-brand* tokens from @theme. Color skill chips in SkillList by proficiency level using the existing c1–c6 chip palette.