### PR TITLE
feat(cv): render technologies as individual badge pills in Experience…

### DIFF
--- a/src/components/cv/ExperienceList.astro
+++ b/src/components/cv/ExperienceList.astro
@@ -2,6 +2,7 @@
 import type { WorkExperience } from "@/types/cv.types";
 import Card from "@/components/ui/Card.astro";
 import SectionTitle from "@/components/ui/SectionTitle.astro";
+import TechBadge from "@/components/ui/TechBadge.astro";
 import { formatDateRange } from "@/utils/formatters";
 import { formatDuration } from "@/utils/date.utils";
 
@@ -64,6 +65,13 @@ const { experiences } = Astro.props;
                 </li>
               ))}
             </ul>
+          )}
+          {exp.technologies.length > 0 && (
+            <div class="mt-3 flex flex-wrap gap-1.5" aria-label="Stack tecnológico">
+              {exp.technologies.map((tech) => (
+                <TechBadge tech={tech} size="sm" />
+              ))}
+            </div>
           )}
         </Card>
       ))

--- a/src/components/home/StudiesSection.astro
+++ b/src/components/home/StudiesSection.astro
@@ -1,5 +1,6 @@
 ---
 import type { Education, AdditionalTraining, Certification } from "@/types/cv.types";
+import TechBadge from "@/components/ui/TechBadge.astro";
 import { formatDate } from "@/utils/formatters";
 
 interface Props {
@@ -21,6 +22,7 @@ interface StudyItem {
   year: string;
   url: string | null;
   description: string | null;
+  technologies: string[];
   sortDate: number;
 }
 
@@ -35,6 +37,7 @@ const educationItems: StudyItem[] = education.map((e) => ({
     : `${new Date(e.start_date).getFullYear()} – actual`,
   url: null,
   description: e.description,
+  technologies: e.technologies,
   sortDate: new Date(e.start_date).getTime(),
 }));
 
@@ -47,6 +50,7 @@ const trainingItems: StudyItem[] = additionalTraining.map((e) => ({
   year: formatDate(e.completion_date),
   url: e.certificate_url,
   description: e.description,
+  technologies: e.technologies,
   sortDate: new Date(e.completion_date).getTime(),
 }));
 
@@ -73,6 +77,22 @@ const certCards = [...certifications].sort(
               <p class="study-provider">{s.institution}</p>
               {s.subtitle && <p class="study-subtitle">{s.subtitle}</p>}
               {s.description && <p class="study-desc">{s.description}</p>}
+              {s.technologies.length > 0 && (
+                <div class="study-techs" aria-label="Stack tecnológico">
+                  {s.technologies
+                    .flatMap((tech) =>
+                      tech.includes(",")
+                        ? tech
+                            .split(",")
+                            .map((t) => t.trim())
+                            .filter(Boolean)
+                        : [tech]
+                    )
+                    .map((tech) => (
+                      <TechBadge tech={tech} size="sm" />
+                    ))}
+                </div>
+              )}
               <div class="study-footer">
                 <span class="study-year">{s.year}</span>
                 {s.url && (
@@ -261,6 +281,13 @@ const certCards = [...certifications].sort(
     color: var(--ink-2);
     line-height: 1.55;
     margin-bottom: 16px;
+  }
+
+  .study-techs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 14px;
   }
 
   .study-footer {

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -567,9 +567,18 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
                     {exp.description && <p class="xp-desc">{exp.description}</p>}
                     {exp.technologies.length > 0 && (
                       <div class="project-tech-list">
-                        {exp.technologies.map((tech) => (
-                          <TechBadge tech={tech} size="sm" />
-                        ))}
+                        {exp.technologies
+                          .flatMap((tech) =>
+                            tech.includes(",")
+                              ? tech
+                                  .split(",")
+                                  .map((t) => t.trim())
+                                  .filter(Boolean)
+                              : [tech]
+                          )
+                          .map((tech) => (
+                            <TechBadge tech={tech} size="sm" />
+                          ))}
                       </div>
                     )}
                   </div>
@@ -603,9 +612,18 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
                     {edu.description && <p class="xp-desc">{edu.description}</p>}
                     {edu.technologies.length > 0 && (
                       <div class="project-tech-list">
-                        {edu.technologies.map((tech) => (
-                          <TechBadge tech={tech} size="sm" />
-                        ))}
+                        {edu.technologies
+                          .flatMap((tech) =>
+                            tech.includes(",")
+                              ? tech
+                                  .split(",")
+                                  .map((t) => t.trim())
+                                  .filter(Boolean)
+                              : [tech]
+                          )
+                          .map((tech) => (
+                            <TechBadge tech={tech} size="sm" />
+                          ))}
                       </div>
                     )}
                   </div>
@@ -656,9 +674,21 @@ const toolsByCategory = tools.reduce<Record<string, Tool[]>>((acc, tool) => {
                       {item.description && <p class="xp-desc">{item.description}</p>}
                       {(item as AdditionalTraining).technologies?.length > 0 && (
                         <div class="project-tech-list">
-                          {(item as AdditionalTraining).technologies.map((tech) => (
+                          {/* {(item as AdditionalTraining).technologies.map((tech) => (
                             <TechBadge tech={tech} size="sm" />
-                          ))}
+                          ))} */}
+                          {(item as AdditionalTraining).technologies
+                            .flatMap((tech) =>
+                              tech.includes(",")
+                                ? tech
+                                    .split(",")
+                                    .map((t) => t.trim())
+                                    .filter(Boolean)
+                                : [tech]
+                            )
+                            .map((tech) => (
+                              <TechBadge tech={tech} size="sm" />
+                            ))}
                         </div>
                       )}
                     </div>


### PR DESCRIPTION
…, Education and Training

Replace plain-text technology lists with TechBadge pills across all three sections in cv.astro, ExperienceList and StudiesSection. Adds comma-split normalization to handle API responses where multiple technologies arrive as a single concatenated string.