### PR TITLE
feat(projects): render image in project cards with gradient fallback

### DIFF
--- a/src/components/home/ProjectsSection.astro
+++ b/src/components/home/ProjectsSection.astro
@@ -32,14 +32,27 @@ const visible = sorted.slice(0, 4);
         <div class="projects-grid">
           {visible.map((p, i) => (
             <div class="project-card">
-              <div class="project-thumb" style={`background: ${GRADIENTS[i % GRADIENTS.length]}`}>
-                <div class="project-thumb-lines">
-                  <>
-                    <span />
-                    <span />
-                    <span />
-                  </>
-                </div>
+              <div
+                class="project-thumb"
+                style={p.image_url ? undefined : `background: ${GRADIENTS[i % GRADIENTS.length]}`}
+              >
+                {p.image_url ? (
+                  <img
+                    class="project-thumb-img"
+                    src={p.image_url}
+                    alt={p.title}
+                    loading="lazy"
+                    decoding="async"
+                  />
+                ) : (
+                  <div class="project-thumb-lines">
+                    <>
+                      <span />
+                      <span />
+                      <span />
+                    </>
+                  </div>
+                )}
               </div>
 
               <div class="project-body">
@@ -201,6 +214,13 @@ const visible = sorted.slice(0, 4);
     align-items: center;
     justify-content: center;
     overflow: hidden;
+  }
+
+  .project-thumb-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
   }
 
   .project-thumb-lines {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -217,6 +217,7 @@ const FALLBACK_PROJECTS: Project[] = [
     live_url: "https://azfe.dev",
     repo_url: "https://github.com/Azfe",
     technologies: ["Astro", "FastAPI", "MongoDB", "Python", "Tailwind"],
+    image_url: null,
     order_index: 1,
     created_at: null,
     updated_at: null,

--- a/src/tests/integration/fixtures/cv.fixtures.ts
+++ b/src/tests/integration/fixtures/cv.fixtures.ts
@@ -117,6 +117,7 @@ export const mockProjects: Project[] = [
     live_url: "https://azfe.dev",
     repo_url: "https://github.com/azfe/portfolio",
     technologies: ["Astro", "FastAPI", "MongoDB", "TypeScript"],
+    image_url: null,
     order_index: 1,
   },
 ];

--- a/src/types/cv.types.ts
+++ b/src/types/cv.types.ts
@@ -59,6 +59,7 @@ export interface Project extends BaseEntity {
   end_date: ISODateString | null;
   live_url: string | null;
   repo_url: string | null;
+  image_url: string | null;
   technologies: string[];
   order_index: number;
 }


### PR DESCRIPTION
Show image_url as a lazy-loaded cover image in the card thumbnail when available; fall back to the existing CSS gradient when image_url is null. Adds image_url field to the Project TypeScript interface.