### PR TITLE
feat(frontend): initial release of Astro portfolio frontend

### DIFF
--- a/src/components/common/Footer.astro
+++ b/src/components/common/Footer.astro
@@ -1,7 +1,28 @@
 ---
 import { SITE } from "@/config/site";
-import { ROUTES } from "@/config/constants";
+import { getContactInfo, getSocialNetworks } from "@/services/api/profile.service";
+import SocialLinks from "@/components/ui/SocialLinks.astro";
+
 const year = new Date().getFullYear();
+
+let email: string | null = "azapatafe@gmail.com";
+let github: string | null = "https://github.com/azfe";
+let linkedin: string | null = "https://linkedin.com/in/alejandrozapataf";
+let website: string | null = "https://azfe.dev";
+let xUrl: string | null = null;
+
+try {
+  const [contact, socials] = await Promise.all([getContactInfo(), getSocialNetworks()]);
+  email = contact.email ?? email;
+  github = contact.github ?? github;
+  linkedin = contact.linkedin ?? linkedin;
+  website = contact.website ?? website;
+  xUrl =
+    socials.find((n) => n.platform.toLowerCase() === "x" || n.platform.toLowerCase() === "twitter")
+      ?.url ?? null;
+} catch {
+  // usa los valores fallback iniciales
+}
 ---
 
 <footer class="footer">
@@ -9,17 +30,15 @@ const year = new Date().getFullYear();
     © {year}
     <strong>{SITE.author}</strong> 👨‍💻 Hecho con dedicación desde Barcelona.
   </p>
-  <div class="footer-links">
-    <a href="mailto:alexzapata1984@gmail.com">Email</a>
-    <span class="footer-sep">·</span>
-    <a href={ROUTES.cv} target="_blank" rel="noopener noreferrer">CV</a>
-    <span class="footer-sep">·</span>
-    <a href="https://github.com/azfe" target="_blank" rel="noopener noreferrer">GitHub</a>
-  </div>
+  <SocialLinks {email} {github} {linkedin} {website} {xUrl} size="sm" />
 </footer>
 
 <style>
   .footer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
     text-align: center;
     padding: 40px 24px;
     color: var(--ink-3);
@@ -31,27 +50,5 @@ const year = new Date().getFullYear();
   .footer strong {
     color: var(--ink-2);
     font-weight: 600;
-  }
-
-  .footer-links {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 10px;
-    margin-top: 8px;
-  }
-
-  .footer-links a {
-    color: var(--ink-3);
-    text-decoration: none;
-    transition: color var(--transition);
-  }
-
-  .footer-links a:hover {
-    color: var(--accent-color);
-  }
-
-  .footer-sep {
-    color: var(--line);
   }
 </style>

--- a/src/components/home/ContactSection.astro
+++ b/src/components/home/ContactSection.astro
@@ -6,17 +6,17 @@ const apiUrl = API_URL ?? "";
 const services = [
   {
     icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>`,
-    title: "Producto end-to-end",
+    title: "Desarrollo de Producto End-to-End",
     description:
-      "Diseño e implementación de APIs, bases de datos y arquitectura backend desde cero hasta producción.",
+      "Solución integral que cubre todo el ciclo de vida del producto: desde la conceptualización de experiencia de usuario (UX) e interfaces visuales (UI), hasta la arquitectura robusta de APIs y bases de datos. Entrego productos digitales terminados, optimizados y listos para salir a producción con un frontend moderno y escalable.",
     meta: "Proyectos de 1–3 meses",
   },
   {
     icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>`,
     title: "Extensión de equipo",
     description:
-      "Refuerzo de equipos de desarrollo con experiencia en Python, FastAPI y buenas prácticas de ingeniería.",
-    meta: "Contratos por horas o sprint",
+      "Integración inmediata en equipos técnicos para acelerar el desarrollo de funcionalidades complejas. Aporto experiencia Full-stack, aplicando metodologías ágiles, revisiones de código y patrones de diseño que garantizan un software mantenible y de alto rendimiento.",
+    meta: "Integración por Sprints o modalidad Mensual",
   },
   {
     icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>`,
@@ -27,10 +27,10 @@ const services = [
   },
   {
     icon: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>`,
-    title: "Mentoria 1:1",
+    title: "Desarrollo de MVP (Producto Mínimo Viable)",
     description:
-      "Sesiones personalizadas para desarrolladores que quieran mejorar en arquitectura backend, Python avanzado o preparación técnica.",
-    meta: "Desde 60€/hora",
+      "Transformación de ideas en productos funcionales en tiempo récord. Enfoque en arquitectura escalable y despliegue rápido para validar modelos de negocio sin desperdiciar recursos.",
+    meta: "Precio cerrado o Time & Materials",
   },
 ];
 ---

--- a/src/components/home/ExperienceSection.astro
+++ b/src/components/home/ExperienceSection.astro
@@ -84,7 +84,7 @@ const sorted = [...experiences].sort((a, b) => {
 <style>
   .xp-section {
     padding: 24px 24px 64px;
-    background-color: var(--bg);
+    /* background-color: var(--bg); */
   }
 
   .section-wrap {

--- a/src/components/home/Hero.astro
+++ b/src/components/home/Hero.astro
@@ -1,11 +1,12 @@
 ---
 import { Image } from "astro:assets";
 import profileImg from "/public/profile.png";
+import SocialLinks from "@/components/ui/SocialLinks.astro";
 
 interface Props {
   name: string;
   headline: string;
-  email: string;
+  email: string | null;
   github: string | null;
   linkedin: string | null;
   xUrl: string | null;
@@ -45,117 +46,7 @@ const { name, headline, email, github, linkedin, xUrl, website } = Astro.props;
   </p>
 
   <!-- Social links -->
-  <div class="hero-socials">
-    <a href={`mailto:${email}`} class="social-btn" title="Email" aria-label="Enviar email">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="18"
-        height="18"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        ><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"
-        ></path><polyline points="22,6 12,13 2,6"></polyline></svg
-      >
-    </a>
-    {
-      github && (
-        <a
-          href={github}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="social-btn"
-          title="GitHub"
-          aria-label="Perfil de GitHub"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-          >
-            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-          </svg>
-        </a>
-      )
-    }
-    {
-      linkedin && (
-        <a
-          href={linkedin}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="social-btn"
-          title="LinkedIn"
-          aria-label="Perfil de LinkedIn"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-          >
-            <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z" />
-          </svg>
-        </a>
-      )
-    }
-    <!-- {
-      xUrl && (
-        <a
-          href={xUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="social-btn"
-          title="X (Twitter)"
-          aria-label="Perfil de X"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="17"
-            height="17"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-          >
-            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-          </svg>
-        </a>
-      )
-    } -->
-    {
-      website && (
-        <a
-          href={website}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="social-btn"
-          title="Website"
-          aria-label="Sitio web"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <circle cx="12" cy="12" r="10" />
-            <line x1="2" y1="12" x2="22" y2="12" />
-            <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
-          </svg>
-        </a>
-      )
-    }
-  </div>
+  <SocialLinks {email} {github} {linkedin} {website} {xUrl} />
 </section>
 
 <style>
@@ -247,37 +138,5 @@ const { name, headline, email, github, linkedin, xUrl, website } = Astro.props;
     border-radius: 50%;
     display: inline-block;
     flex-shrink: 0;
-  }
-
-  .hero-socials {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-  }
-
-  .social-btn {
-    width: 44px;
-    height: 44px;
-    border-radius: 50%;
-    border: 1.5px solid var(--line);
-    background: var(--card);
-    color: var(--ink-2);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    text-decoration: none;
-    transition:
-      border-color var(--transition),
-      color var(--transition),
-      box-shadow var(--transition),
-      background var(--transition);
-    box-shadow: var(--shadow-card);
-  }
-
-  .social-btn:hover {
-    border-color: var(--accent-color);
-    color: var(--accent-color);
-    background: var(--accent-color-soft);
-    box-shadow: 0 2px 12px rgba(30, 107, 247, 0.15);
   }
 </style>

--- a/src/components/ui/SocialLinks.astro
+++ b/src/components/ui/SocialLinks.astro
@@ -1,0 +1,167 @@
+---
+interface Props {
+  email?: string | null;
+  github?: string | null;
+  linkedin?: string | null;
+  website?: string | null;
+  xUrl?: string | null;
+  size?: "md" | "sm";
+}
+
+const { email, github, linkedin, website, xUrl, size = "md" } = Astro.props;
+
+const btnSize = size === "sm" ? "36px" : "44px";
+const iconSize = size === "sm" ? 15 : 18;
+const iconSizeX = size === "sm" ? 14 : 17;
+---
+
+<div class="social-links" style={`--btn-size: ${btnSize}`}>
+  {
+    email && (
+      <a href={`mailto:${email}`} class="social-btn" title="Email" aria-label="Enviar email">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={iconSize}
+          height={iconSize}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
+          <polyline points="22,6 12,13 2,6" />
+        </svg>
+      </a>
+    )
+  }
+  {
+    github && (
+      <a
+        href={github}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="social-btn"
+        title="GitHub"
+        aria-label="Perfil de GitHub"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={iconSize}
+          height={iconSize}
+          viewBox="0 0 24 24"
+          fill="currentColor"
+        >
+          <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+        </svg>
+      </a>
+    )
+  }
+  {
+    linkedin && (
+      <a
+        href={linkedin}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="social-btn"
+        title="LinkedIn"
+        aria-label="Perfil de LinkedIn"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={iconSize}
+          height={iconSize}
+          viewBox="0 0 24 24"
+          fill="currentColor"
+        >
+          <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z" />
+        </svg>
+      </a>
+    )
+  }
+  {
+    xUrl && (
+      <a
+        href={xUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="social-btn"
+        title="X (Twitter)"
+        aria-label="Perfil de X"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={iconSizeX}
+          height={iconSizeX}
+          viewBox="0 0 24 24"
+          fill="currentColor"
+        >
+          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+        </svg>
+      </a>
+    )
+  }
+  {
+    website && (
+      <a
+        href={website}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="social-btn"
+        title="Website"
+        aria-label="Sitio web"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width={iconSize}
+          height={iconSize}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <line x1="2" y1="12" x2="22" y2="12" />
+          <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+        </svg>
+      </a>
+    )
+  }
+</div>
+
+<style>
+  .social-links {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .social-btn {
+    width: var(--btn-size, 44px);
+    height: var(--btn-size, 44px);
+    border-radius: 50%;
+    border: 1.5px solid var(--line);
+    background: var(--card);
+    color: var(--ink-2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+    transition:
+      border-color var(--transition),
+      color var(--transition),
+      box-shadow var(--transition),
+      background var(--transition);
+    box-shadow: var(--shadow-card);
+  }
+
+  .social-btn:hover {
+    border-color: var(--accent-color);
+    color: var(--accent-color);
+    background: var(--accent-color-soft);
+    box-shadow: 0 2px 12px rgba(30, 107, 247, 0.15);
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,6 +20,7 @@ import ProjectsSection from "@/components/home/ProjectsSection.astro";
 import ContactSection from "@/components/home/ContactSection.astro";
 import { PAGE_SEO } from "@/config/seo";
 import { getCVComplete } from "@/services/api/cv.service";
+import { getContactInfo, getSocialNetworks } from "@/services/api/profile.service";
 import { fetchPageData } from "@/utils/error-handler";
 import type {
   WorkExperience,
@@ -56,14 +57,28 @@ if (cvResult.ok) {
 
 const name = cv?.profile.name ?? "Alex Zapata";
 const headline = cv?.profile.headline ?? "Software developer · Fullstack · UI designer";
-const email = cv?.contact_info?.email ?? "alexzapata1984@gmail.com";
-const github = cv?.contact_info?.github ?? "https://github.com/azfe";
-const linkedin = cv?.contact_info?.linkedin ?? "https://linkedin.com/in/alexzapata";
-const website = cv?.contact_info?.website ?? "https://azfe.dev";
-const xUrl =
-  cv?.social_networks?.find(
-    (n) => n.platform.toLowerCase() === "x" || n.platform.toLowerCase() === "twitter"
-  )?.url ?? "https://x.com/azfe_dev";
+
+let email: string | null = "azapatafe@gmail.com";
+let github: string | null = "https://github.com/azfe";
+let linkedin: string | null = "https://linkedin.com/in/alejandrozapataf";
+let website: string | null = "https://azfe.dev";
+let xUrl: string | null = null;
+
+try {
+  const [contact, socials] = await Promise.all([getContactInfo(), getSocialNetworks()]);
+  email = contact.email ?? email;
+  github = contact.github ?? github;
+  linkedin = contact.linkedin ?? linkedin;
+  website = contact.website ?? website;
+  xUrl =
+    socials.find((n) => n.platform.toLowerCase() === "x" || n.platform.toLowerCase() === "twitter")
+      ?.url ?? null;
+} catch {
+  email = "azapatafe@gmail.com";
+  github = "https://github.com/azfe";
+  linkedin = "https://linkedin.com/in/alejandrozapataf";
+  website = "https://azfe.dev";
+}
 
 const bio =
   cv?.profile.bio ??


### PR DESCRIPTION
## Summary

- Scaffolds the complete Astro 6 + Tailwind CSS v4 + TypeScript frontend from zero, merging the full `develop` history into `main` for the first production-ready release.
- Implements SSR landing page (`/`) connected to the backend API, a static `/projects` page, and a standalone CV viewer (served from `public/cv/`) that redirects to `cv.azfe.dev`.
- Adds all UI component layers: common (Header, Footer, Navigation, SEO), home sections (Hero, AboutMe, ExperienceSection, StudiesSection, ProjectsSection, ContactSection), CV components (ProfileCard, ExperienceList, SkillList), and a full `ui/` primitives library (Badge, Button, Card, TechBadge, SectionTitle, Spinner, SkeletonBlock, SocialLinks).
- Introduces interactive React islands: `ContactForm`, `DownloadButton` (PDF via backend), `ScrollToTop`, `HamburgerMenu`, and canvas-based `WaveBackground`.
- Wires up the HTTP base client and all resource API services (`cv`, `profile`, `experience`, `skill`, `education`, `contact`) with normalized error handling and loading states.
- Aligns TypeScript types with the backend API contract (`CompleteCV`, `WorkExperience`, `Skill`, `Tool`, etc.).
- Configures the full toolchain: ESLint 10, Prettier 3, Vitest 4 (unit + integration), Husky pre-commit hooks, Lighthouse CI (Performance ≥ 0.9, Accessibility ≥ 0.9, SEO ≥ 0.9), and five GitHub Actions workflows (build, lint, unit tests, e2e placeholder, Lighthouse).
- Applies responsive design throughout, including hamburger menu for mobile and accessible color-contrast-compliant theming with light mode as default.